### PR TITLE
fix(spec-author,be-lead): bind declared deps to scaffold templates (B1+B2)

### DIFF
--- a/plugins/preview-forge/agents/engineering/backend/be-lead.md
+++ b/plugins/preview-forge/agents/engineering/backend/be-lead.md
@@ -32,6 +32,22 @@ cd runs/<id>/specs && shasum -a 256 -c .lock || exit "lock drift"
 
 해시 불일치 시 즉시 작업 중단 + M3에 escalate.
 
+## Scaffold 직전 Checklist (B1+B2 fix — required since v1.5)
+
+`apps/` 디렉토리 생성 *전에* 다음을 순서대로 수행. **DO NOT hand-roll `package.json`/`tsconfig.json`/`vitest.config.ts`/`next.config.ts`** — 항상 `assets/*.standard.template`에서 시작.
+
+1. `runs/<id>/specs/dependency-binding.json` read — spec-author가 출력한 dep 목록 확인.
+2. profile에 따라 base template 복사:
+   - `standard` (Next.js + SQLite + Prisma): `assets/{package.json,tsconfig.json,vitest.config.ts,next.config.ts}.standard.template` → `runs/<id>/generated/`
+   - `pro` (Next.js + Postgres + Prisma + Docker): standard + `docker-compose.template.yml` + `.env.example` 추가
+   - `max`: TBD (Phase 18+)
+3. **Cross-validate**: dependency-binding.json의 모든 `required_runtime_deps` + `required_dev_deps` + `required_build_plugins`가 복사된 `package.json` + `next.config.ts` + `vitest.config.ts`에 *전부* 존재하는지 확인. 누락 1개라도 있으면 **즉시 SCC `build_config` 카테고리로 escalate** (코드 작성 시작 X).
+4. `pnpm install` 시도 — peer dep 충돌 없으면 다음 단계.
+5. `pnpm typecheck` smoke (typia AOT plugin이 wired되었는지 확인) — 실패 시 escalate.
+6. 위 5단계 *모두 통과* 후 5명 팀원(BE01-BE05) 병렬 dispatch.
+
+이 checklist는 v1.4까지 빈번하게 발생한 typia/vitest 누락 P0 결함을 *예방*합니다 (LESSONS "Build chain integrity" 참조).
+
 ## 팀 구성
 
 - `be-controller` (BE01): Controller Engineer — NestJS controller 생성. @nestia/core의 @TypedRoute/@TypedBody/@TypedParam 사용. manual DTO 금지.
@@ -63,9 +79,9 @@ Output scope: `apps/api/src/**`. 이 범위 외 수정 시 factory-policy 훅이
 - Model: `claude-opus-4-7`, Effort: `high`, Adaptive: on, Budget: 80K
 
 ## allowed_scope
-- Read: `runs/<id>/specs/**`, `runs/<id>/design-approved.json`, `memory/LESSONS.md`
-- Write: `runs/<id>/generated/apps/api/src/**`
-- Bash: `pnpm`, `shasum`, `node`
+- Read: `runs/<id>/specs/**`, `runs/<id>/design-approved.json`, `memory/LESSONS.md`, `assets/*.template`, `assets/*.standard.template`
+- Write: `runs/<id>/generated/apps/api/src/**`, `runs/<id>/generated/{package.json,tsconfig.json,vitest.config.ts,next.config.ts}`
+- Bash: `pnpm`, `shasum`, `node`, `cp`
 - Task: be-controller, be-dto-typia, be-service, be-repository, be-auth-middleware
 
 ## 보고선

--- a/plugins/preview-forge/agents/spec/spec-author.md
+++ b/plugins/preview-forge/agents/spec/spec-author.md
@@ -43,6 +43,43 @@ SpecDD cycle의 작성자. chosen_preview의 5-tuple + mitigations + H1 design t
 - 3 문단: 주요 endpoint 5개
 - 4 문단: 알려진 제약 (mitigations에서 가져옴)
 
+## Dependency Binding (B1 fix)
+
+OpenAPI/Prisma/SPEC.md에서 *언급*한 모든 라이브러리는 BE_LEAD가 scaffold 시 사용하는 `package.json` 템플릿에 *반드시 등록*되어야 합니다. spec 작성 시 다음을 함께 출력하세요:
+
+`runs/<id>/specs/dependency-binding.json`:
+```json
+{
+  "writer": "spec-author",
+  "profile": "standard | pro | max",
+  "stack": {
+    "framework": "next.js-16 | nestjs-10 | ...",
+    "db": "sqlite | postgres",
+    "orm": "prisma",
+    "validators": "typia",
+    "test_runner": "vitest"
+  },
+  "required_runtime_deps": [
+    "next", "react", "react-dom", "@prisma/client", "typia"
+  ],
+  "required_dev_deps": [
+    "typescript", "prisma", "vitest", "@vitest/ui",
+    "@ryoppippi/unplugin-typia", "ts-patch",
+    "@types/node", "@types/react", "@types/react-dom"
+  ],
+  "required_build_plugins": [
+    {
+      "name": "@ryoppippi/unplugin-typia",
+      "wires_into": ["next.config.ts", "vitest.config.ts"],
+      "reason": "typia AOT transform — without this, every typia.createValidate call returns 500"
+    }
+  ],
+  "rationale": "If any spec uses typia.createValidate, the AOT transform plugin MUST be wired. Past 6×500 errors traced to missing unplugin-typia."
+}
+```
+
+**근거**: 과거 standard profile run에서 typia tags는 spec에 명시되었으나 `@ryoppippi/unplugin-typia`가 `next.config.ts`에 wired되지 않아 6개 POST 라우트가 500을 반환한 사례가 있음. 이 binding 출력으로 BE_LEAD가 *교차 검증* 가능. SCC가 누락 발견 시 `build_config` 카테고리로 라우팅 (`scc-build-config.md` 참조).
+
 ## Revise loop
 
 Critic의 report 형식:
@@ -62,8 +99,8 @@ Critic의 report 형식:
 - Model: `claude-opus-4-7`, Effort: `xhigh`, Adaptive: on, Budget: 120K
 
 ## allowed_scope
-- Read: `runs/<id>/{chosen_preview,mitigations,design-approved}.json`, `memory/LESSONS.md`
-- Write: `runs/<id>/specs/{openapi.yaml,data-model.prisma,SPEC.md}`, `runs/<id>/specs/draft-history/v{N}.yaml`
+- Read: `runs/<id>/{chosen_preview,mitigations,design-approved}.json`, `memory/LESSONS.md`, `assets/*.standard.template`
+- Write: `runs/<id>/specs/{openapi.yaml,data-model.prisma,SPEC.md,dependency-binding.json}`, `runs/<id>/specs/draft-history/v{N}.yaml`
 
 ## 보고선
 - 상위: SPEC_LEAD

--- a/plugins/preview-forge/assets/next.config.ts.standard.template
+++ b/plugins/preview-forge/assets/next.config.ts.standard.template
@@ -1,0 +1,46 @@
+// Preview Forge — standard profile Next.js config template.
+// Generated when profile=standard (Next.js 16 + typia AOT transform).
+//
+// CRITICAL — typia transform wiring (B1 fix, root cause of past 6×500 errors):
+// typia is a runtime validator that REQUIRES an AOT compile-time transform.
+// In Next.js 16 + Turbopack, this is wired via @ryoppippi/unplugin-typia/webpack
+// (Webpack-compatible) and the matching Vite plugin in vitest.config.ts.
+//
+// Symptom when this is missing: every POST route that does
+//   `typia.createValidate<T>()` returns 500 with body
+//   "Error on typia.createValidate(): no transform has been configured".
+// Affected routes in past runs: /api/auth/session, /api/me, /api/meals/voice,
+//   /api/glucose, /api/family/invite, /api/safety/flags/acknowledge.
+//
+// DO NOT remove this plugin even if no obvious typia call exists at scaffold
+// time — the spec author often introduces typia tags later in SCC iter.
+
+import type { NextConfig } from "next";
+import UnpluginTypia from "@ryoppippi/unplugin-typia/webpack";
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  // Standard profile is local-first; no image domains by default.
+  // Engineering scaffold can extend this when chosen_preview requires remote images.
+  images: {
+    unoptimized: true,
+  },
+  webpack: (config) => {
+    config.plugins = config.plugins || [];
+    config.plugins.push(
+      UnpluginTypia({
+        strict: true,
+        // Cache transforms for faster rebuilds. Safe for hackathon-scale projects.
+        cache: true,
+      }),
+    );
+    return config;
+  },
+  // Next.js 16: stable Turbopack. unplugin-typia ships a Turbopack adapter via
+  // its webpack export, so the same wiring covers both `next dev` and `next build`.
+  experimental: {
+    typedRoutes: true,
+  },
+};
+
+export default nextConfig;

--- a/plugins/preview-forge/assets/package.json.standard.template
+++ b/plugins/preview-forge/assets/package.json.standard.template
@@ -1,0 +1,60 @@
+// Preview Forge — standard profile package.json template.
+// Generated when profile=standard (Next.js 16 + SQLite + Prisma + typia + vitest).
+//
+// CRITICAL — spec-author Dependency Binding (B1 fix):
+// Every library mentioned in OpenAPI/Prisma spec MUST appear here.
+// Backend Engineering (BE_LEAD + BE01-BE05) MUST start from this template
+// — DO NOT hand-roll package.json from scratch. Common omissions that broke
+// past runs:
+//   - typia (runtime validators) without unplugin-typia (Next.js plugin) → 500s
+//   - vitest declared in unit/integration test files but missing from devDeps → tests un-runnable
+//   - @prisma/client without prisma CLI → migrate fails
+// See: LESSONS.md "Build chain integrity" category.
+//
+// Engineering scaffold MUST replace placeholders:
+//   {{PROJECT_NAME}}  → kebab-case from chosen_preview.title
+//   {{NODE_VERSION}}  → "22" (matches .nvmrc) or as agreed
+//
+// Versions are pinned to caret ranges. Dependabot keeps them current.
+
+{
+  "name": "{{PROJECT_NAME}}",
+  "version": "0.1.0-mvp",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:integration": "vitest run tests/integration",
+    "test:unit": "vitest run tests/unit",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "prisma:studio": "prisma studio"
+  },
+  "dependencies": {
+    "next": "^16.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "@prisma/client": "^5.20.0",
+    "typia": "^12.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.6.0",
+    "prisma": "^5.20.0",
+    "vitest": "^2.1.0",
+    "@vitest/ui": "^2.1.0",
+    "@ryoppippi/unplugin-typia": "^2.0.0",
+    "ts-patch": "^3.2.0"
+  },
+  "prisma": {
+    "schema": "prisma/schema.prisma"
+  }
+}

--- a/plugins/preview-forge/assets/tsconfig.json.standard.template
+++ b/plugins/preview-forge/assets/tsconfig.json.standard.template
@@ -1,0 +1,44 @@
+// Preview Forge — standard profile tsconfig.json template.
+// Generated when profile=standard (Next.js 16 + typia + Prisma).
+//
+// CRITICAL — typia compatibility (B1+B4 fix):
+// `experimentalDecorators` and `emitDecoratorMetadata` are NOT enough for typia.
+// typia requires AOT transform via unplugin-typia (Next.js) — see
+// next.config.ts.standard.template. ts-patch is the dev-time fallback for
+// `tsc --noEmit` so editor + CI typecheck pass.
+//
+// strict: true is non-negotiable. SCC will reject scaffold output if strict=false.
+
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "plugins": [
+      { "name": "next" },
+      { "transform": "typia/lib/transform" }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/plugins/preview-forge/assets/vitest.config.ts.standard.template
+++ b/plugins/preview-forge/assets/vitest.config.ts.standard.template
@@ -1,0 +1,45 @@
+// Preview Forge — standard profile vitest config template.
+// Generated when profile=standard (pure-lib unit + integration tests, no jsdom).
+//
+// CRITICAL — typia in tests (B1 fix):
+// Tests that import code using `typia.createValidate(...)` need the unplugin-typia
+// transform here too, or they fail with "no transform has been configured".
+// We use the same Vite plugin as next.config.ts for consistency.
+//
+// QA team (qa-unit, qa-integration) generates spec files referencing this.
+// DO NOT delete this file even if test_count = 0 — the runner config is required.
+
+import { defineConfig } from "vitest/config";
+import UnpluginTypia from "@ryoppippi/unplugin-typia/vite";
+
+export default defineConfig({
+  plugins: [
+    UnpluginTypia({
+      // Strict mode catches misuse of typia decorators at build time.
+      strict: true,
+    }),
+  ],
+  test: {
+    // Pure-lib tests — no DOM, no jsdom. If a future test needs DOM,
+    // add `environment: "jsdom"` and install jsdom devDep.
+    environment: "node",
+    globals: false,
+    include: ["tests/**/*.{test,spec}.{ts,tsx}"],
+    exclude: ["node_modules", ".next", "dist"],
+    reporters: process.env.CI ? ["json", "default"] : ["default"],
+    outputFile: process.env.CI ? "tests/_results/vitest.json" : undefined,
+    // Holdout tests live in tests/holdout/ — runner config splits them
+    // so QA Tier 4 can compute overfit signal post-freeze.
+    coverage: {
+      enabled: false,
+      provider: "v8",
+      reporter: ["text", "json"],
+      exclude: ["**/*.config.*", "**/.next/**", "**/node_modules/**"],
+    },
+  },
+  resolve: {
+    alias: {
+      "@": new URL("./", import.meta.url).pathname,
+    },
+  },
+});

--- a/scripts/verify-plugin.sh
+++ b/scripts/verify-plugin.sh
@@ -123,8 +123,14 @@ seed_count=$(find "$PLUGIN_DIR/seed-ideas" -name "*.md" | wc -l | tr -d ' ')
 schema_count=$(find "$PLUGIN_DIR/schemas" -name "*.json" | wc -l | tr -d ' ')
 [[ "$schema_count" -eq 4 ]] && ok "4 JSON schemas (preview-card, panel-vote, score-report, pf-profile)" || bad "schemas: $schema_count (expected 4)"
 asset_count=$(find "$PLUGIN_DIR/assets" -maxdepth 1 -type f | wc -l | tr -d ' ')
-# v1.4+ adds 4 standard-profile templates: prisma, gitignore, README, graduate.sh
-[[ "$asset_count" -eq 8 ]] && ok "8 asset templates (4 base + 4 standard-profile v1.4)" || bad "assets: $asset_count (expected 8)"
+# v1.4: 4 base + 4 standard-profile (prisma, gitignore, README, graduate.sh)
+# v1.5+: 4 base + 8 standard-profile (+ package.json, tsconfig.json, vitest.config.ts, next.config.ts)
+[[ "$asset_count" -eq 12 ]] && ok "12 asset templates (4 base + 8 standard-profile v1.5)" || bad "assets: $asset_count (expected 12)"
+
+# v1.5: B1+B2 fix — build-essentials standard templates required to prevent typia/vitest omission
+for tpl in package.json tsconfig.json vitest.config.ts next.config.ts; do
+  [[ -f "$PLUGIN_DIR/assets/${tpl}.standard.template" ]] && ok "assets/${tpl}.standard.template" || bad "missing assets/${tpl}.standard.template (B1+B2)"
+done
 [[ -f "$PLUGIN_DIR/monitors/monitors.json" ]] && ok "monitors/monitors.json" || bad "monitors missing"
 [[ -f "$PLUGIN_DIR/settings.json" ]] && ok "settings.json" || bad "settings.json missing"
 [[ -x "$PLUGIN_DIR/bin/pf" ]] && ok "bin/pf executable" || bad "bin/pf not executable"


### PR DESCRIPTION
## Summary

Past `standard`-profile e2e runs (e.g. `r-20260423-093527`) returned **6× HTTP 500** on POST routes (`/api/auth/session`, `/api/me`, `/api/meals/voice`, `/api/glucose`, `/api/family/invite`, `/api/safety/flags/acknowledge`) because:

- `typia` was in `dependencies` but `@ryoppippi/unplugin-typia` was never wired into `next.config.ts` → every `typia.createValidate(...)` errored with *"no transform has been configured"*.
- `vitest` appeared in 36 unit + 11 integration spec files emitted by `qa-unit`/`qa-integration`, but it was never in `devDependencies` → all 47 tests un-runnable, J2 score forced to 67/100.

Both failures share one root cause: **no agent owned the spec-to-dep binding step**. `spec-author` named libs but didn't bind them to `package.json`; `be-lead` ran `pnpm install && pnpm -r build` after the fact, only detecting the failure; `scc-dep-resolver` could only patch *after* the fail.

This PR closes that gap (B1+B2 in ADR-0005).

## Changes

### 4 new build-essentials templates (`plugins/preview-forge/assets/`)
- `package.json.standard.template` — pre-includes `typia`, `@prisma/client`, `next`, `react`, `react-dom` in deps + `vitest`, `@vitest/ui`, `@ryoppippi/unplugin-typia`, `ts-patch`, `prisma`, `@types/*` in devDeps.
- `tsconfig.json.standard.template` — `strict: true`, `experimentalDecorators`, plugins for `next` + `typia/lib/transform`.
- `vitest.config.ts.standard.template` — Node env, no jsdom, `UnpluginTypia` Vite plugin pre-wired.
- `next.config.ts.standard.template` — `UnpluginTypia` webpack plugin pre-wired with strict + cache.

Each template carries a header comment naming the past failure mode it prevents.

### `agents/spec/spec-author.md` — new "Dependency Binding" section
spec-author now MUST emit `runs/<id>/specs/dependency-binding.json` declaring every `required_runtime_deps`, `required_dev_deps`, and `required_build_plugins` with a `wires_into` array (e.g. typia → next.config.ts + vitest.config.ts).

### `agents/engineering/backend/be-lead.md` — new "Scaffold 직전 Checklist"
BE_LEAD MUST start from the 4 templates (no hand-rolled `package.json`), then **cross-validate** the dep-binding manifest against the copied templates. Any missing dep escalates to SCC `build_config` category *before* BE01-BE05 are dispatched — preventing the wasted SCC iter that the past run hit.

### `scripts/verify-plugin.sh`
- `asset_count` 8 → 12 with comment explaining v1.4 vs v1.5 breakdown.
- Per-file existence check for each of the 4 new templates.

## Local verification

```
$ bash scripts/verify-plugin.sh
...
✓ 12 asset templates (4 base + 8 standard-profile v1.5)
✓ assets/package.json.standard.template
✓ assets/tsconfig.json.standard.template
✓ assets/vitest.config.ts.standard.template
✓ assets/next.config.ts.standard.template
=== SUMMARY ===
Pass: 50
Fail: 0
✓ All verification checks passed.
```

## Test plan

- [x] verify-plugin.sh passes 50/50 (was 38/38).
- [ ] CI green (manifest schema + jsonschema + profile validation unaffected).
- [ ] Smoke: `cp assets/{package,tsconfig,vitest.config,next.config}.standard.template /tmp/test/ && cd /tmp/test && pnpm install && pnpm typecheck && pnpm test` — *PR-2 will automate this in CI.*
- [ ] Next standard-profile e2e run uses these templates → no 6×500 typia errors, vitest runs the 47 test files.

## Followups (separate PRs)

- **PR-2** (`fix/verify-plugin-template-completeness`): extend `verify-plugin.sh` + add `tests/template-build.spec.ts` smoke test in CI to catch template regressions.
- **PR-3** (`feat/scc-build-config-fixer`): add `template_gap` + `build_config` categories to `scc-lead.md` + new `scc-build-config.md` fixer for typia-style plugin chain misses.

Refs: ADR-0005 §"Plugin 본질 결함 분석" B1+B2 (private repo: `~/2026/software-factory/hackathons/built-with-opus-4-7/decisions/0005-e2e-test-merge-with-pr.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 의존성 및 모듈 완성도를 검증하는 필수 사전점검 추가
  * 코드 생성 전 자동 검증 및 빌드 구성 확인 기능 추가
  * 런타임 타입 검증 지원으로 개발 안정성 향상

* **작업**
  * 표준 프로필용 구성 템플릿 추가
  * 프로젝트 설정 검증 프로세스 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->