### PR TITLE
feat(scc): add build_config + template_gap categories + scc-build-config fixer (B4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,7 @@ jobs:
           echo "✓ preview-cache: 4/4 tests pass"
 
   agent-counts:
-    name: Agent inventory (143 target)
+    name: Agent inventory (144 target)
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -425,13 +425,13 @@ jobs:
       - name: Count agents
         run: |
           TOTAL=$(find plugins/preview-forge/agents -name "*.md" -type f | wc -l)
-          if [[ "$TOTAL" -ne 143 ]]; then
-            echo "::error::Expected 143 agents, found $TOTAL"
+          if [[ "$TOTAL" -ne 144 ]]; then
+            echo "::error::Expected 144 agents, found $TOTAL"
             exit 1
           fi
-          echo "✓ 143/143 agents present"
+          echo "✓ 144/144 agents present"
 
-          # per-dept
+          # per-dept (v1.5: scc 5 → 6 with scc-build-config)
           declare -A EXPECTED=(
             [meta]=3
             [ideation]=29
@@ -439,7 +439,7 @@ jobs:
             [spec]=9
             [engineering]=25
             [qa]=14
-            [scc]=5
+            [scc]=6
             [judges]=5
             [auditors]=5
             [docs]=3
@@ -467,7 +467,7 @@ jobs:
               for f, m in non_opus:
                   print(f"::error file={f}::non-Opus model: {m}")
               sys.exit(1)
-          print("✓ all 143 agents use Opus 4.7")
+          print("✓ all 144 agents use Opus 4.7")
           PYEOF
 
       - name: Check agent name uniqueness

--- a/plugins/preview-forge/agents/scc/scc-build-config.md
+++ b/plugins/preview-forge/agents/scc/scc-build-config.md
@@ -1,0 +1,64 @@
+---
+name: scc-build-config
+description: SCC Build Config Fixer Tier 5 — Self-Correction Squad. Build plugin chain 누락·오설정 fixer (typia AOT transform, vitest config plugin, next.config webpack, tsconfig plugins). Code-level bug도 dep-level 충돌도 아닌, *bridge*가 끊긴 경우 (B1+B2+B4 fix).
+tools: Read, Write, Edit, Bash
+model: opus
+---
+
+# SCC-BUILD-CONFIG — SCC Build Config Fixer (Tier 5 · TestDD Self-Correction)
+
+## Layer-0
+```
+@methodology/global.md
+```
+
+## 역할
+
+`scc-dep` (의존성 누락) 도 `scc-backend` (코드 버그) 도 아닌 *세 번째 카테고리*: **build plugin chain이 끊김**. 의존성도 있고 코드도 정상인데 *transform/plugin이 wired 안 되어* 빌드는 통과하지만 런타임에 500이 나는 부류.
+
+**대표 사례** (과거 r-20260423-093527에서 발견):
+- `typia^12`은 `dependencies`에 있으나 `@ryoppippi/unplugin-typia`가 `next.config.ts` webpack에 wired 안 됨 → 6 POST 라우트 500 with "no transform has been configured"
+- `vitest`가 spec 파일에서 import되나 `devDependencies`에 미등록 (또는 `vitest.config.ts` 없음) → `pnpm test` ELIFECYCLE
+- `tsconfig.json`에 `typia/lib/transform` plugin 없으면 `tsc --noEmit`은 typia 오용 미감지
+
+## 분류 신호 (이 fixer가 호출되는 trigger)
+
+`scc-lead`가 다음 패턴 감지 시 dispatch:
+- 런타임 에러 메시지에 "no transform has been configured"
+- `pnpm test` exit 2 with "vitest: command not found"
+- `tsc --noEmit` 출력에 typia tags 미인식 (TS2304/TS2339)
+- next/vite/webpack config 파일에 expected plugin import 누락 (grep로 확인)
+- `runs/<id>/specs/dependency-binding.json`의 `required_build_plugins`가 실제 config 파일에 wired 안 됨
+
+## 실행 원칙
+
+- **잠금 존중**: `specs/openapi.yaml` / `data-model.prisma` / `.lock` 파일 수정 금지
+- **Holdout 존중**: `tests/.holdout/**` 수정 금지 (overfit 방지)
+- **Template 우선**: `assets/{package.json,tsconfig.json,vitest.config.ts,next.config.ts}.standard.template`을 *reference*로. 차이를 발견하면 template 쪽으로 정렬 (역방향 금지).
+- **최소 diff**: 누락된 plugin/import 추가만. 무관한 refactor 금지.
+- **Test 삭제로 통과시키기 금지**: hard block (factory-policy 훅이 감지)
+
+## 표준 fix 절차
+
+1. `runs/<id>/specs/dependency-binding.json` read (spec-author 출력)
+2. `runs/<id>/generated/{package.json,tsconfig.json,vitest.config.ts,next.config.ts}` read
+3. cross-validate:
+   - `required_runtime_deps` ⊆ `dependencies`
+   - `required_dev_deps` ⊆ `devDependencies`
+   - `required_build_plugins[].wires_into` 각 파일이 plugin import + 사용 패턴 포함
+4. 누락 발견 시:
+   - `assets/*.standard.template`에서 해당 줄 복사 (재발명 금지)
+   - 최소 diff로 patch
+5. `pnpm install --no-frozen-lockfile && pnpm typecheck` smoke
+6. 성공 시 escalate 0; 실패 시 M3에 "template/spec 불일치"로 escalate (코드 차원 fix 아님)
+
+## 모델 설정
+- Model: `claude-opus-4-7`, Effort: `high`, Adaptive: on, Budget: 80K
+
+## allowed_scope
+- Read: `runs/<id>/**`, `plugins/preview-forge/assets/*.standard.template`
+- Write: `runs/<id>/generated/{package.json,tsconfig.json,vitest.config.ts,next.config.ts,vite.config.ts,*.config.*}`
+- Bash: `pnpm`, `node`, `tsc`
+
+## 보고선
+- 상위: SCC_LEAD → M3 Dev PM

--- a/plugins/preview-forge/agents/scc/scc-lead.md
+++ b/plugins/preview-forge/agents/scc/scc-lead.md
@@ -39,6 +39,28 @@ Active profile에서 `scc.max_iter`를 로드:
 
 **Plateau 규칙**: 3회 연속 error count 정체 시 auto-extend 없이 즉시 중단 + M3 escalate.
 
+## 실패 분류 + Fixer Dispatch (v1.5+ — B4 fix)
+
+각 실패 신호를 다음 카테고리로 분류 후 해당 fixer로 dispatch:
+
+| 카테고리 | 신호 | Fixer | Escalation |
+|---------|------|-------|-----------|
+| `code_bug` | runtime exception, logic error, typia validation FAIL on legal input | `scc-backend` 또는 `scc-frontend` | iter cap 도달 시 M3 |
+| `type_error` | `tsc --noEmit` TS2xxx (typia tags 인식 후) | `scc-type` | iter cap 도달 시 M3 |
+| `dep_missing` | pnpm install 실패, `Cannot find module`, peer dep 충돌 | `scc-dep` | iter cap 도달 시 M3 |
+| **`build_config`** ✦v1.5 | `"no transform has been configured"`, `vitest: command not found`, plugin import 누락 (next.config/vitest.config/tsconfig) | **`scc-build-config`** | template/spec 불일치 시 즉시 M3 |
+| **`template_gap`** ✦v1.5 | spec-author의 `dependency-binding.json`에 명시되지 않은 dep을 코드가 사용 | (자체 fix 불가) | **즉시 M3** — spec-author 재호출 필요 |
+| `spec_violation` | code가 openapi.yaml과 충돌 (lock hash mismatch) | (자체 fix 불가) | **즉시 M3** — Change Proposal 필요 |
+| `test_flake` | 같은 테스트가 random pass/fail | quarantine + log | iter 종료 시 M3 보고 |
+
+**중요**: `build_config`와 `template_gap`은 코드 차원 fix가 *근본 해결 아님*.
+- `build_config`: `scc-build-config`가 `assets/*.standard.template`과 *정렬*시키는 정도까지만. 그 이상은 M3 escalate.
+- `template_gap`: *항상* spec-author 재호출 필요 (SCC가 spec 못 만짐). v1.4에서 이 카테고리가 부재해 typia transform 누락이 `dep_missing`으로 오분류된 사례 있음 (LESSONS "Build chain integrity" 참조).
+
+**Auto-extend 트리거 차등** (v1.5+):
+- `dep_missing`/`build_config` 에러는 처음 2회까지 *자동 +1 연장* (의존성·plugin chain 수정은 수렴이 빠름).
+- `code_bug`/`type_error`는 기본 정책 (errors decreasing이어야 +1).
+
 ## 모델 설정
 - Model: `claude-opus-4-7`, Effort: `high`, Adaptive: on, Budget: profile-aware (standard 56K · pro 64K · max 80K)
 

--- a/plugins/preview-forge/memory/LESSONS.md
+++ b/plugins/preview-forge/memory/LESSONS.md
@@ -119,6 +119,16 @@
 8. **디자인 통합**: Claude Design 연동·fallback
 9. **Agent 커뮤니케이션**: Blackboard·Hierarchical 보고선
 10. **Layer-0·Security**: 훅·차단 패턴·blocked_actions
+11. **Build chain integrity** ✦v1.5: spec→template→build_plugin chain 정합성 (typia AOT, vitest config, tsconfig plugins, next.config webpack)
+
+---
+
+## LESSON 11.1 — Build chain integrity (2026-04-23)
+
+- **문제**: Run `r-20260423-093527` (당뇨환자 식단, standard profile)에서 6 POST 라우트가 *"Error on typia.createValidate(): no transform has been configured"*로 500 응답. 36 unit + 11 integration test 미실행. score 451/500 (J2: 67 FAIL), freeze 미달.
+- **원인**: spec-author가 typia tags 명시 + BE_LEAD가 `typia^12`을 deps에 추가. 그러나 `@ryoppippi/unplugin-typia` (Next.js plugin)이 `next.config.ts` webpack에 wired 안 됨. `vitest`도 spec 파일 import만 있고 devDeps 미등록. SCC가 `dep_missing`으로 *오분류* → 해결 못 함.
+- **해결**: (1) `assets/{package.json,tsconfig.json,vitest.config.ts,next.config.ts}.standard.template` 4개 추가, plugin chain pre-wired (PR #9, B1+B2). (2) spec-author "Dependency Binding" 섹션 + be-lead "Scaffold 직전 Checklist" (PR #9). (3) `scripts/test-templates.sh` + CI `template-build` job (PR #11, B3) — pnpm install + typecheck로 PR time 검증. (4) `agents/scc/scc-build-config.md` 신규 fixer + scc-lead 분류 카테고리 `build_config`/`template_gap` 추가 (PR #12, B4).
+- **참조**: ADR-0005 §"Plugin 본질 결함 분석" B1+B2+B3+B4. PR #9 e67e92e, PR #11 5a4d1d4, PR #12 (this).
 
 ---
 

--- a/scripts/verify-plugin.sh
+++ b/scripts/verify-plugin.sh
@@ -45,10 +45,10 @@ echo
 
 echo "[2/5] Agents (143 target)"
 agent_count=$(find "$PLUGIN_DIR/agents" -name "*.md" -type f | wc -l | tr -d ' ')
-if [[ "$agent_count" -eq 143 ]]; then
-  ok "agent count: 143 (target met)"
+if [[ "$agent_count" -eq 144 ]]; then
+  ok "agent count: 144 (v1.5 target met — adds scc-build-config)"
 else
-  bad "agent count: $agent_count (expected 143)"
+  bad "agent count: $agent_count (expected 144)"
 fi
 python3 <<PYEOF && ok "all agents have valid frontmatter" || bad "some agents have invalid frontmatter"
 import re, glob


### PR DESCRIPTION
## Summary

In v1.4 the SCC error classifier had **no category** for the most common real-world failure mode observed in run `r-20260423-093527`: build plugin chain misses. typia/vitest were misclassified as `dep_missing`, dispatched to `scc-dep` which only ran `pnpm install`, never patching `next.config.ts` webpack or `vitest.config.ts` plugins. SCC iter terminated with `freeze=false`, score 451/500 (J2: 67 FAIL), and the run shipped broken.

This PR closes the classification gap (B4 in ADR-0005). It composes with PR #9 (template binding) and PR #11 (CI smoke) to make the typia-class regression *catch-able* at three layers: spec, CI, and SCC.

## Changes

### `plugins/preview-forge/agents/scc/scc-build-config.md` (NEW, +6th SCC member)
Dedicated fixer for `build_config` failures:
- Reads `runs/<id>/specs/dependency-binding.json` (emitted by spec-author per PR #9).
- Cross-validates against generated `package.json` / `tsconfig.json` / `vitest.config.ts` / `next.config.ts`.
- Patches by *aligning* with `assets/*.standard.template` (no re-invention).
- Escalates to M3 when the gap is template-side, not code-side.

### `plugins/preview-forge/agents/scc/scc-lead.md`
Explicit **failure classification + fixer dispatch table**. New categories:
- `build_config`: typia AOT, vitest config, next.config webpack, tsconfig plugins → `scc-build-config`
- `template_gap`: spec-declared dep missing from `dependency-binding.json` → immediate M3 escalate (SCC can't fix specs)

Plus differential auto-extend: `dep_missing` and `build_config` get +1 free retry (they converge fast), `code_bug` / `type_error` keep the existing errors-decreasing rule.

### `plugins/preview-forge/memory/LESSONS.md`
New category 11 **"Build chain integrity"** + LESSON 11.1 documenting:
- Root cause of `r-20260423-093527` (6×500 from missing `@ryoppippi/unplugin-typia`)
- Why SCC's `dep_missing` mis-categorization made it un-fixable
- The v1.5 four-PR fix chain (B1+B2 → B3 → B4) for cross-reference

### `ci.yml` + `scripts/verify-plugin.sh`
- Agent total: 143 → 144
- `scc` dept: 5 → 6
- Job name: "Agent inventory (143 target)" → "(144 target)"
- Updated comment + log strings

## Local verification

```
$ bash scripts/verify-plugin.sh
...
✓ agent count: 144 (v1.5 target met — adds scc-build-config)
✓ all agents have valid frontmatter
✓ all agents use Opus 4.7
=== SUMMARY ===
Pass: 50  Fail: 0
```

## Test plan

- [x] verify-plugin.sh passes 50/50.
- [ ] CI passes: `agent-counts` (144 total, scc=6), `template-build` (still green from PR #11), `verify-plugin`, `test-hooks`, `lint-shell`.
- [ ] Negative test: simulate a future run where typia exists in deps but unplugin-typia is missing → SCC classifies as `build_config` (not `dep_missing`), dispatches `scc-build-config`, which reads `dependency-binding.json` and patches `next.config.ts` from template.

## Closes the v1.5 PR series

| PR | Fix | Layer |
|----|-----|-------|
| #9 (e67e92e) | B1+B2: spec→dep binding + 4 templates | Prevention (templates pre-include the chain) |
| #11 (5a4d1d4) | B3: CI template-build smoke job | Detection (CI catches regressions at PR time) |
| **#12 (this)** | B4: SCC `build_config` classification + fixer | Recovery (when prevention/detection both miss, SCC self-heals) |

Together: the typia/vitest class of bugs is now caught at three layers. ADR-0005 §"Plugin 본질 결함 분석" complete.

Refs: ADR-0005 §"Plugin 본질 결함 분석" B4

🤖 Generated with [Claude Code](https://claude.com/claude-code)