### PR TITLE
fix: address PR #9 + #11 + #12 post-merge review feedback (CRITICAL package.json)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,9 +536,9 @@ jobs:
           for tpl in package.json tsconfig.json vitest.config.ts next.config.ts; do
             cp "plugins/preview-forge/assets/${tpl}.standard.template" "$WS/$tpl"
           done
-          # Strip header comments from JSON files (templates carry comments for humans).
-          sed -i '/^\/\//d' "$WS/package.json" "$WS/tsconfig.json"
-          # Substitute placeholders.
+          # Substitute placeholders. (Since PR #13 the JSON templates are
+          # strict JSON — no `//` comment stripping needed; human guidance
+          # lives in package.json.standard.README.md.)
           sed -i 's/{{PROJECT_NAME}}/pf-template-smoke/g' "$WS/package.json"
           sed -i 's/{{NODE_VERSION}}/22/g' "$WS/package.json"
           # Minimal typia-using source so `tsc --noEmit` exercises the transform plugin.

--- a/plugins/preview-forge/agents/scc/scc-build-config.md
+++ b/plugins/preview-forge/agents/scc/scc-build-config.md
@@ -49,7 +49,7 @@ model: opus
 4. 누락 발견 시:
    - `assets/*.standard.template`에서 해당 줄 복사 (재발명 금지)
    - 최소 diff로 patch
-5. `pnpm install --no-frozen-lockfile && pnpm typecheck` smoke
+5. `pnpm install --no-frozen-lockfile && pnpm typecheck` (둘 다 0 exit)
 6. 성공 시 escalate 0; 실패 시 M3에 "template/spec 불일치"로 escalate (코드 차원 fix 아님)
 
 ## 모델 설정
@@ -57,7 +57,7 @@ model: opus
 
 ## allowed_scope
 - Read: `runs/<id>/**`, `plugins/preview-forge/assets/*.standard.template`
-- Write: `runs/<id>/generated/{package.json,tsconfig.json,vitest.config.ts,next.config.ts,vite.config.ts,*.config.*}`
+- Write: `runs/<id>/generated/{package.json,tsconfig.json,vitest.config.ts,next.config.ts}` (위 §"표준 fix 절차" 4단계의 template-aligned 파일들로 한정 — `*.config.*` 와일드카드는 의도치 않은 설정 덮어쓰기 위험으로 제외)
 - Bash: `pnpm`, `node`, `tsc`
 
 ## 보고선

--- a/plugins/preview-forge/assets/graduate.sh.template
+++ b/plugins/preview-forge/assets/graduate.sh.template
@@ -50,18 +50,18 @@ fi
 if [[ ! -f Dockerfile ]]; then
   cat > Dockerfile <<'DOCKERFILE'
 # Preview Forge — generated on graduate to pro/max
-FROM node:20-alpine AS deps
+FROM node:22-alpine AS deps
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev
 
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build
 
-FROM node:20-alpine
+FROM node:22-alpine
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=builder /app/.next ./.next
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
-        with: { node-version: '20' }
+        with: { node-version: '22' }
       - run: npm ci
       - run: npm run build
       - run: docker build -t $IMAGE .

--- a/plugins/preview-forge/assets/graduate.sh.template
+++ b/plugins/preview-forge/assets/graduate.sh.template
@@ -50,27 +50,36 @@ fi
 if [[ ! -f Dockerfile ]]; then
   cat > Dockerfile <<'DOCKERFILE'
 # Preview Forge — generated on graduate to pro/max
-# NOTE: package.json declares `prepare: "ts-patch install -s"` (typia AOT
-# transform). ts-patch is a devDependency, so production-only stages MUST
-# use `--ignore-scripts` to avoid running prepare without ts-patch installed.
+# NOTE: ts-patch (typia AOT transform) is a build-time tool only. We do
+# NOT use a `prepare` lifecycle script for it (would break production
+# `npm ci --omit=dev` even with --ignore-scripts because that also skips
+# Prisma postinstall — runtime image then ships without generated client).
+# Instead the builder stage installs ts-patch explicitly.
 
-# Stage 1: production deps only (no devDeps, skip lifecycle scripts).
+# Stage 1: production deps only. Lifecycle scripts ARE allowed so Prisma
+# postinstall can generate the client into node_modules. ts-patch isn't
+# needed here (it's a devDep, omitted) and there's no `prepare` script
+# that would reference it.
 FROM node:22-alpine AS deps
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --omit=dev --ignore-scripts
+COPY prisma ./prisma
+RUN npm ci --omit=dev
 
-# Stage 2: full install (devDeps included) — prepare runs here so ts-patch
-# is present, the typia transform is wired, and `next build` succeeds.
+# Stage 2: full install + explicit ts-patch + build. ts-patch is a
+# devDependency so it's present here. We invoke it explicitly (not via
+# prepare hook) so the production stage above stays clean.
 FROM node:22-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+COPY prisma ./prisma
+RUN npm ci \
+ && npx ts-patch install -s
 COPY . .
 RUN npm run build
 
-# Stage 3: minimal runtime image. Re-uses the slim production-only modules
-# from Stage 1, plus the build output from Stage 2.
+# Stage 3: minimal runtime image. Slim production node_modules from
+# Stage 1 (with Prisma client generated), build output from Stage 2.
 FROM node:22-alpine
 WORKDIR /app
 ENV NODE_ENV=production

--- a/plugins/preview-forge/assets/graduate.sh.template
+++ b/plugins/preview-forge/assets/graduate.sh.template
@@ -50,23 +50,33 @@ fi
 if [[ ! -f Dockerfile ]]; then
   cat > Dockerfile <<'DOCKERFILE'
 # Preview Forge — generated on graduate to pro/max
+# NOTE: package.json declares `prepare: "ts-patch install -s"` (typia AOT
+# transform). ts-patch is a devDependency, so production-only stages MUST
+# use `--ignore-scripts` to avoid running prepare without ts-patch installed.
+
+# Stage 1: production deps only (no devDeps, skip lifecycle scripts).
 FROM node:22-alpine AS deps
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev --ignore-scripts
 
+# Stage 2: full install (devDeps included) — prepare runs here so ts-patch
+# is present, the typia transform is wired, and `next build` succeeds.
 FROM node:22-alpine AS builder
 WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
+COPY package*.json ./
+RUN npm ci
 COPY . .
 RUN npm run build
 
+# Stage 3: minimal runtime image. Re-uses the slim production-only modules
+# from Stage 1, plus the build output from Stage 2.
 FROM node:22-alpine
 WORKDIR /app
 ENV NODE_ENV=production
+COPY --from=deps /app/node_modules ./node_modules
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
-COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
 EXPOSE 3000
 CMD ["npm","run","start"]

--- a/plugins/preview-forge/assets/graduate.sh.template
+++ b/plugins/preview-forge/assets/graduate.sh.template
@@ -56,15 +56,19 @@ if [[ ! -f Dockerfile ]]; then
 # Prisma postinstall — runtime image then ships without generated client).
 # Instead the builder stage installs ts-patch explicitly.
 
-# Stage 1: production deps only. Lifecycle scripts ARE allowed so Prisma
-# postinstall can generate the client into node_modules. ts-patch isn't
-# needed here (it's a devDep, omitted) and there's no `prepare` script
-# that would reference it.
+# Stage 1: production deps + Prisma client generation. Doing a FULL
+# `npm ci` first (incl. devDeps so the prisma CLI is available),
+# generating the client, then pruning devDeps. The standalone
+# `@prisma/client` postinstall would NOT generate the client when
+# devDeps are omitted (CodeRabbit Critical, PR #13 wave 6: prisma CLI
+# is a devDep, postinstall has nothing to invoke).
 FROM node:22-alpine AS deps
 WORKDIR /app
 COPY package*.json ./
 COPY prisma ./prisma
-RUN npm ci --omit=dev
+RUN npm ci \
+ && npx --yes prisma generate \
+ && npm prune --omit=dev
 
 # Stage 2: full install + explicit ts-patch + build. ts-patch is a
 # devDependency so it's present here. We invoke it explicitly (not via

--- a/plugins/preview-forge/assets/package.json.standard.README.md
+++ b/plugins/preview-forge/assets/package.json.standard.README.md
@@ -27,7 +27,10 @@ Past omissions that broke runs (LESSONS 11.1):
 - `typia: ^7.0.0` — current stable (was incorrectly `^12` in v1.5.0,
   fixed in PR #13).
 - `ts-patch: ^3.2.0` — required by typia for AOT transform during
-  `tsc --noEmit`. The `prepare` script auto-runs it on `pnpm install`.
+  `tsc --noEmit`. **Build-time only** — NOT a `prepare` lifecycle script
+  (would break `npm ci --omit=dev` in production Docker stages). Builder
+  must run `npx ts-patch install -s` explicitly before `npm run build`.
+  See `assets/graduate.sh.template` Stage 2 for the canonical pattern.
 - `@ryoppippi/unplugin-typia: ^2.0.0` — Next.js webpack plugin that
   wires the typia transform. Without this, every `typia.createValidate`
   call returns 500 at runtime even though the build succeeds.

--- a/plugins/preview-forge/assets/package.json.standard.README.md
+++ b/plugins/preview-forge/assets/package.json.standard.README.md
@@ -1,0 +1,42 @@
+# `package.json.standard.template` — Notes for BE_LEAD
+
+> Why this file is bare JSON (no `//` comments): JSON spec doesn't allow
+> comments. The previous version had `//` headers that broke `JSON.parse`
+> when BE_LEAD's `cp` step copied the template directly. Caught in PR #9
+> review (gemini-code-assist + chatgpt-codex). Fixed in PR #13.
+
+## What this template guarantees
+
+Every library mentioned in the OpenAPI/Prisma spec MUST appear here.
+Backend Engineering (BE_LEAD + BE01–BE05) MUST start from this template
+— **DO NOT hand-roll `package.json` from scratch**.
+
+Past omissions that broke runs (LESSONS 11.1):
+- `typia` (runtime validators) without `@ryoppippi/unplugin-typia`
+  (Next.js plugin) → 6×500 on POST routes.
+- `vitest` declared in unit/integration test files but missing from
+  devDeps → 47 tests un-runnable, J2 score forced to 67/100.
+
+## Engineering scaffold MUST replace placeholders
+
+- `{{PROJECT_NAME}}` → kebab-case derived from `chosen_preview.title`
+- `{{NODE_VERSION}}` → `22` (matches `.nvmrc`) or as agreed in spec
+
+## Why these specific versions
+
+- `typia: ^7.0.0` — current stable (was incorrectly `^12` in v1.5.0,
+  fixed in PR #13).
+- `ts-patch: ^3.2.0` — required by typia for AOT transform during
+  `tsc --noEmit`. The `prepare` script auto-runs it on `pnpm install`.
+- `@ryoppippi/unplugin-typia: ^2.0.0` — Next.js webpack plugin that
+  wires the typia transform. Without this, every `typia.createValidate`
+  call returns 500 at runtime even though the build succeeds.
+- `vitest: ^2.1.0` — pinned to the major version qa-unit/qa-integration
+  generators target.
+
+## Verification
+
+`scripts/test-templates.sh` (run in CI as `template-build` job) renders
+this template + drops a minimal `lib/check.ts` using `typia.createValidate`,
+then runs `pnpm install` + `pnpm typecheck`. If any of the above goes
+out of sync (e.g. typia major version changes), CI fails at PR time.

--- a/plugins/preview-forge/assets/package.json.standard.template
+++ b/plugins/preview-forge/assets/package.json.standard.template
@@ -1,28 +1,13 @@
-// Preview Forge — standard profile package.json template.
-// Generated when profile=standard (Next.js 16 + SQLite + Prisma + typia + vitest).
-//
-// CRITICAL — spec-author Dependency Binding (B1 fix):
-// Every library mentioned in OpenAPI/Prisma spec MUST appear here.
-// Backend Engineering (BE_LEAD + BE01-BE05) MUST start from this template
-// — DO NOT hand-roll package.json from scratch. Common omissions that broke
-// past runs:
-//   - typia (runtime validators) without unplugin-typia (Next.js plugin) → 500s
-//   - vitest declared in unit/integration test files but missing from devDeps → tests un-runnable
-//   - @prisma/client without prisma CLI → migrate fails
-// See: LESSONS.md "Build chain integrity" category.
-//
-// Engineering scaffold MUST replace placeholders:
-//   {{PROJECT_NAME}}  → kebab-case from chosen_preview.title
-//   {{NODE_VERSION}}  → "22" (matches .nvmrc) or as agreed
-//
-// Versions are pinned to caret ranges. Dependabot keeps them current.
-
 {
   "name": "{{PROJECT_NAME}}",
   "version": "0.1.0-mvp",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">={{NODE_VERSION}}"
+  },
   "scripts": {
+    "prepare": "ts-patch install -s",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
@@ -41,7 +26,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "@prisma/client": "^5.20.0",
-    "typia": "^12.0.0"
+    "typia": "^7.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/plugins/preview-forge/assets/package.json.standard.template
+++ b/plugins/preview-forge/assets/package.json.standard.template
@@ -7,7 +7,6 @@
     "node": ">={{NODE_VERSION}}"
   },
   "scripts": {
-    "prepare": "ts-patch install -s",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",

--- a/plugins/preview-forge/assets/tsconfig.json.standard.template
+++ b/plugins/preview-forge/assets/tsconfig.json.standard.template
@@ -1,14 +1,3 @@
-// Preview Forge — standard profile tsconfig.json template.
-// Generated when profile=standard (Next.js 16 + typia + Prisma).
-//
-// CRITICAL — typia compatibility (B1+B4 fix):
-// `experimentalDecorators` and `emitDecoratorMetadata` are NOT enough for typia.
-// typia requires AOT transform via unplugin-typia (Next.js) — see
-// next.config.ts.standard.template. ts-patch is the dev-time fallback for
-// `tsc --noEmit` so editor + CI typecheck pass.
-//
-// strict: true is non-negotiable. SCC will reject scaffold output if strict=false.
-
 {
   "compilerOptions": {
     "target": "ES2022",

--- a/plugins/preview-forge/assets/vitest.config.ts.standard.template
+++ b/plugins/preview-forge/assets/vitest.config.ts.standard.template
@@ -10,6 +10,7 @@
 // DO NOT delete this file even if test_count = 0 — the runner config is required.
 
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
 import UnpluginTypia from "@ryoppippi/unplugin-typia/vite";
 
 export default defineConfig({
@@ -38,7 +39,9 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@": new URL("./", import.meta.url).pathname,
+      // fileURLToPath is the cross-platform safe way (Windows-friendly)
+      // to convert import.meta.url to a filesystem path.
+      "@": fileURLToPath(new URL("./", import.meta.url)),
     },
   },
 });

--- a/scripts/test-templates.sh
+++ b/scripts/test-templates.sh
@@ -87,23 +87,24 @@ ok "tsconfig.json parses"
 echo
 
 echo "[4/4] Static content checks (B1+B2 fix verification)"
-# package.json: assert each dep is in dependencies OR devDependencies (JSON-aware,
-# not just raw grep — a dep name appearing in `scripts` shouldn't count).
-python3 - "$TMPDIR/package.json" <<'PY' || exit 2
+# package.json: assert each required dep is in dependencies OR devDependencies
+# (JSON-aware — raw grep would false-positive on `scripts:` containing dep names).
+# Iterate per-dep and use the shared ok/bad helpers so the summary stays accurate
+# even when this list grows or shrinks (gemini-code-assist PR #13 review).
+required_deps=(typia vitest "@ryoppippi/unplugin-typia" ts-patch "@prisma/client" next react)
+for dep in "${required_deps[@]}"; do
+  if python3 - "$TMPDIR/package.json" "$dep" <<'PY' >/dev/null 2>&1
 import json, sys
 pkg = json.load(open(sys.argv[1]))
 declared = set(pkg.get("dependencies", {}).keys()) | set(pkg.get("devDependencies", {}).keys())
-required = ["typia", "vitest", "@ryoppippi/unplugin-typia", "ts-patch",
-            "@prisma/client", "next", "react"]
-missing = [d for d in required if d not in declared]
-if missing:
-    for m in missing:
-        print(f"  ✗ package.json MISSING {m} (would re-introduce past failure)")
-    sys.exit(2)
-for d in required:
-    print(f"  ✓ package.json declares {d} (in deps or devDeps)")
+sys.exit(0 if sys.argv[2] in declared else 1)
 PY
-pass=$((pass+7))
+  then
+    ok "package.json declares $dep (in deps or devDeps)"
+  else
+    bad "package.json MISSING $dep (would re-introduce past failure)"
+  fi
+done
 
 # next.config.ts must IMPORT *and* CALL UnpluginTypia (not just import).
 if grep -q "import.*UnpluginTypia.*from" "$TMPDIR/next.config.ts" \
@@ -122,15 +123,17 @@ else
 fi
 
 # tsconfig.json must enable typia transform plugin (JSON-aware).
-python3 - "$TMPDIR/tsconfig.json" <<'PY' && pass=$((pass+1)) || { fail=$((fail+1)); echo "  ✗ tsconfig.json plugins missing typia/lib/transform"; }
+if python3 - "$TMPDIR/tsconfig.json" <<'PY' >/dev/null 2>&1
 import json, sys
 ts = json.load(open(sys.argv[1]))
 plugins = ts.get("compilerOptions", {}).get("plugins", [])
-if any(p.get("transform") == "typia/lib/transform" for p in plugins if isinstance(p, dict)):
-    print("  ✓ tsconfig.json declares typia/lib/transform plugin")
-    sys.exit(0)
-sys.exit(1)
+sys.exit(0 if any(p.get("transform") == "typia/lib/transform" for p in plugins if isinstance(p, dict)) else 1)
 PY
+then
+  ok "tsconfig.json declares typia/lib/transform plugin"
+else
+  bad "tsconfig.json plugins missing typia/lib/transform"
+fi
 echo
 
 echo "=== SUMMARY ==="

--- a/scripts/test-templates.sh
+++ b/scripts/test-templates.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
-# Preview Forge — template build smoke test (PR-2 / B3 fix).
-# Verifies that the 4 standard-profile build-essentials templates
-# can produce a project that passes `pnpm install` + `pnpm typecheck`
-# from a clean state. This catches the typia/vitest/unplugin omission
-# class of bugs *at PR time*, not at user e2e time.
+# Preview Forge — template static checks (PR-2 + PR-13).
+# Verifies that the 4 standard-profile build-essentials templates are
+# valid JSON / TS *and* declare the right deps & plugin wiring.
 #
-# Skipped: `pnpm build` (Next.js full build is ~2-5 min, too heavy for
-# every PR). The typecheck pass already exercises the typia AOT plugin
-# wiring via `tsc --noEmit` with the typia transform.
+# This script does STATIC checks only — `pnpm install` and `pnpm typecheck`
+# are run by the CI `template-build` job (see .github/workflows/ci.yml).
 #
 # Usage:
 #   bash scripts/test-templates.sh           # writes to mktemp dir
 #   PF_KEEP_TMP=1 bash scripts/test-templates.sh   # keep tmp dir for debug
 #
-# Exit codes: 0 pass, 1 setup fail, 2 install fail, 3 typecheck fail
+# Exit codes:
+#   0  pass
+#   1  setup fail (missing template)
+#   2  static check fail (JSON parse, missing dep, missing plugin wiring)
 
 set -euo pipefail
 
@@ -34,7 +34,7 @@ pass=0; fail=0
 ok()  { echo "  ✓ $1"; pass=$((pass+1)); }
 bad() { echo "  ✗ $1"; fail=$((fail+1)); }
 
-echo "=== Preview Forge template build smoke ==="
+echo "=== Preview Forge template static checks ==="
 echo "Tmp: $TMPDIR"
 echo
 
@@ -51,81 +51,86 @@ for tpl in package.json tsconfig.json vitest.config.ts next.config.ts; do
 done
 echo
 
-echo "[2/4] Substitute placeholders"
-# package.json.standard.template uses {{PROJECT_NAME}} / {{NODE_VERSION}}
-# Replace with smoke-test values so JSON parses.
-# Use sed -i with empty backup arg for cross-platform (BSD vs GNU sed).
+echo "[2/4] Substitute placeholders in package.json"
 case "$(uname -s)" in
   Darwin) SED_INPLACE=(-i '') ;;
   *)      SED_INPLACE=(-i)    ;;
 esac
-
-# Strip leading // comment lines from JSON files (templates carry header comments).
-# package.json + tsconfig.json must be valid JSON; sed below removes lines starting with `//`.
-for jsonf in package.json tsconfig.json; do
-  sed "${SED_INPLACE[@]}" '/^\/\//d' "$TMPDIR/$jsonf"
-done
-
 sed "${SED_INPLACE[@]}" 's/{{PROJECT_NAME}}/pf-template-smoke/g' "$TMPDIR/package.json"
 sed "${SED_INPLACE[@]}" 's/{{NODE_VERSION}}/22/g' "$TMPDIR/package.json"
 ok "placeholders substituted"
 echo
 
-echo "[3/4] Validate JSON syntax"
-if ! python3 -c "import json; json.load(open('$TMPDIR/package.json'))" 2>/dev/null; then
-  bad "package.json is not valid JSON after placeholder substitution"
+echo "[3/4] Validate JSON syntax (templates must be strict JSON since PR #13)"
+# Pass paths as positional args (avoid shell-injection / quoting issues).
+if ! python3 - "$TMPDIR/package.json" <<'PY' 2>/dev/null
+import json, sys
+json.load(open(sys.argv[1]))
+PY
+then
+  bad "package.json is not valid JSON"
   cat "$TMPDIR/package.json"
-  exit 1
+  exit 2
 fi
 ok "package.json parses"
 
-if ! python3 -c "import json; json.load(open('$TMPDIR/tsconfig.json'))" 2>/dev/null; then
-  bad "tsconfig.json is not valid JSON after comment strip"
+if ! python3 - "$TMPDIR/tsconfig.json" <<'PY' 2>/dev/null
+import json, sys
+json.load(open(sys.argv[1]))
+PY
+then
+  bad "tsconfig.json is not valid JSON"
   cat "$TMPDIR/tsconfig.json"
-  exit 1
+  exit 2
 fi
 ok "tsconfig.json parses"
 echo
 
 echo "[4/4] Static content checks (B1+B2 fix verification)"
-# package.json must declare typia + vitest + unplugin-typia
-declare -a REQUIRED_DEPS=(
-  "typia"
-  "vitest"
-  "@ryoppippi/unplugin-typia"
-  "ts-patch"
-  "@prisma/client"
-  "next"
-  "react"
-)
-for dep in "${REQUIRED_DEPS[@]}"; do
-  if grep -q "\"$dep\"" "$TMPDIR/package.json"; then
-    ok "package.json declares $dep"
-  else
-    bad "package.json MISSING $dep (would re-introduce past failure)"
-  fi
-done
+# package.json: assert each dep is in dependencies OR devDependencies (JSON-aware,
+# not just raw grep — a dep name appearing in `scripts` shouldn't count).
+python3 - "$TMPDIR/package.json" <<'PY' || exit 2
+import json, sys
+pkg = json.load(open(sys.argv[1]))
+declared = set(pkg.get("dependencies", {}).keys()) | set(pkg.get("devDependencies", {}).keys())
+required = ["typia", "vitest", "@ryoppippi/unplugin-typia", "ts-patch",
+            "@prisma/client", "next", "react"]
+missing = [d for d in required if d not in declared]
+if missing:
+    for m in missing:
+        print(f"  ✗ package.json MISSING {m} (would re-introduce past failure)")
+    sys.exit(2)
+for d in required:
+    print(f"  ✓ package.json declares {d} (in deps or devDeps)")
+PY
+pass=$((pass+7))
 
-# next.config.ts must wire UnpluginTypia
-if grep -q "UnpluginTypia" "$TMPDIR/next.config.ts"; then
-  ok "next.config.ts wires UnpluginTypia (typia AOT transform)"
+# next.config.ts must IMPORT *and* CALL UnpluginTypia (not just import).
+if grep -q "import.*UnpluginTypia.*from" "$TMPDIR/next.config.ts" \
+   && grep -q "UnpluginTypia(" "$TMPDIR/next.config.ts"; then
+  ok "next.config.ts imports + calls UnpluginTypia (typia AOT transform wired)"
 else
-  bad "next.config.ts MISSING UnpluginTypia — past 6×500 errors will recur"
+  bad "next.config.ts MISSING UnpluginTypia call — past 6×500 errors will recur"
 fi
 
-# vitest.config.ts must wire UnpluginTypia (so test files using typia compile)
-if grep -q "UnpluginTypia" "$TMPDIR/vitest.config.ts"; then
-  ok "vitest.config.ts wires UnpluginTypia"
+# vitest.config.ts: same check (import + call).
+if grep -q "import.*UnpluginTypia.*from" "$TMPDIR/vitest.config.ts" \
+   && grep -q "UnpluginTypia(" "$TMPDIR/vitest.config.ts"; then
+  ok "vitest.config.ts imports + calls UnpluginTypia"
 else
-  bad "vitest.config.ts MISSING UnpluginTypia — typia in tests will fail"
+  bad "vitest.config.ts MISSING UnpluginTypia call — typia in tests will fail"
 fi
 
-# tsconfig.json must enable typia transform plugin
-if grep -q "typia/lib/transform" "$TMPDIR/tsconfig.json"; then
-  ok "tsconfig.json declares typia/lib/transform plugin"
-else
-  bad "tsconfig.json MISSING typia/lib/transform — tsc --noEmit will not catch typia misuse"
-fi
+# tsconfig.json must enable typia transform plugin (JSON-aware).
+python3 - "$TMPDIR/tsconfig.json" <<'PY' && pass=$((pass+1)) || { fail=$((fail+1)); echo "  ✗ tsconfig.json plugins missing typia/lib/transform"; }
+import json, sys
+ts = json.load(open(sys.argv[1]))
+plugins = ts.get("compilerOptions", {}).get("plugins", [])
+if any(p.get("transform") == "typia/lib/transform" for p in plugins if isinstance(p, dict)):
+    print("  ✓ tsconfig.json declares typia/lib/transform plugin")
+    sys.exit(0)
+sys.exit(1)
+PY
 echo
 
 echo "=== SUMMARY ==="
@@ -135,9 +140,9 @@ echo
 
 if [[ "$fail" -eq 0 ]]; then
   echo "✓ Template static checks passed."
-  echo "  (pnpm install + typecheck not run here — see CI 'template-build' job for full smoke.)"
+  echo "  (pnpm install + typecheck run separately by CI 'template-build' job.)"
   exit 0
 else
   echo "✗ $fail static check(s) failed. The B1/B2 fix would regress."
-  exit 3
+  exit 2
 fi

--- a/scripts/verify-plugin.sh
+++ b/scripts/verify-plugin.sh
@@ -122,11 +122,12 @@ seed_count=$(find "$PLUGIN_DIR/seed-ideas" -name "*.md" | wc -l | tr -d ' ')
 [[ "$seed_count" -eq 10 ]] && ok "10 seed ideas" || bad "seed-ideas: $seed_count (expected 10)"
 schema_count=$(find "$PLUGIN_DIR/schemas" -name "*.json" | wc -l | tr -d ' ')
 [[ "$schema_count" -eq 4 ]] && ok "4 JSON schemas (preview-card, panel-vote, score-report, pf-profile)" || bad "schemas: $schema_count (expected 4)"
-asset_count=$(find "$PLUGIN_DIR/assets" -maxdepth 1 -type f -name "*template*" | wc -l | tr -d ' ')
+asset_count=$(find "$PLUGIN_DIR/assets" -maxdepth 1 -type f ! -name "*.md" ! -name ".*" | wc -l | tr -d ' ')
 # v1.4: 4 base + 4 standard-profile (prisma, gitignore, README, graduate.sh)
 # v1.5+: 4 base + 8 standard-profile (+ package.json, tsconfig.json, vitest.config.ts, next.config.ts)
-# Match `*template*` to cover both `*.template` and `docker-compose.template.yml`-style naming.
-# Excludes README .md siblings (no `template` substring) introduced in v1.5.1.
+# Explicit exclude of `.md` (template-sibling READMEs since v1.5.1) and dotfiles.
+# This is more robust than positive `*template*` matching, which would silently
+# drop a future template that lacked the substring (gemini-code-assist PR #13 review).
 [[ "$asset_count" -eq 12 ]] && ok "12 asset templates (4 base + 8 standard-profile v1.5)" || bad "assets: $asset_count templates (expected 12)"
 
 # v1.5: B1+B2 fix — build-essentials standard templates required to prevent typia/vitest omission

--- a/scripts/verify-plugin.sh
+++ b/scripts/verify-plugin.sh
@@ -4,7 +4,7 @@
 #
 # Checks:
 #   1. Manifest JSON syntax (marketplace.json + plugin.json)
-#   2. All 143 agents present with valid frontmatter
+#   2. All 144 agents present with valid frontmatter
 #   3. 14 slash commands present
 #   4. 3 hooks + hooks.json valid
 #   5. Memory seed + methodology + assets + schemas + seeds present
@@ -43,7 +43,7 @@ print(d['version'])
   ok "plugin.json: name=pf v$(cat /tmp/pf_version)  (marketplace parity ✓)" || bad "plugin.json invalid"
 echo
 
-echo "[2/5] Agents (143 target)"
+echo "[2/5] Agents (144 target)"
 agent_count=$(find "$PLUGIN_DIR/agents" -name "*.md" -type f | wc -l | tr -d ' ')
 if [[ "$agent_count" -eq 144 ]]; then
   ok "agent count: 144 (v1.5 target met — adds scc-build-config)"
@@ -122,10 +122,12 @@ seed_count=$(find "$PLUGIN_DIR/seed-ideas" -name "*.md" | wc -l | tr -d ' ')
 [[ "$seed_count" -eq 10 ]] && ok "10 seed ideas" || bad "seed-ideas: $seed_count (expected 10)"
 schema_count=$(find "$PLUGIN_DIR/schemas" -name "*.json" | wc -l | tr -d ' ')
 [[ "$schema_count" -eq 4 ]] && ok "4 JSON schemas (preview-card, panel-vote, score-report, pf-profile)" || bad "schemas: $schema_count (expected 4)"
-asset_count=$(find "$PLUGIN_DIR/assets" -maxdepth 1 -type f | wc -l | tr -d ' ')
+asset_count=$(find "$PLUGIN_DIR/assets" -maxdepth 1 -type f -name "*template*" | wc -l | tr -d ' ')
 # v1.4: 4 base + 4 standard-profile (prisma, gitignore, README, graduate.sh)
 # v1.5+: 4 base + 8 standard-profile (+ package.json, tsconfig.json, vitest.config.ts, next.config.ts)
-[[ "$asset_count" -eq 12 ]] && ok "12 asset templates (4 base + 8 standard-profile v1.5)" || bad "assets: $asset_count (expected 12)"
+# Match `*template*` to cover both `*.template` and `docker-compose.template.yml`-style naming.
+# Excludes README .md siblings (no `template` substring) introduced in v1.5.1.
+[[ "$asset_count" -eq 12 ]] && ok "12 asset templates (4 base + 8 standard-profile v1.5)" || bad "assets: $asset_count templates (expected 12)"
 
 # v1.5: B1+B2 fix — build-essentials standard templates required to prevent typia/vitest omission
 for tpl in package.json tsconfig.json vitest.config.ts next.config.ts; do


### PR DESCRIPTION
## Why this PR exists

In v1.5.0 I (the author of #9, #11, #12) merged each PR after CI passed but **before fetching or addressing the review comments left by gemini-code-assist and chatgpt-codex**. CodeRabbit was rate-limited so its review never landed either. As a result several actionable items — including a CRITICAL one — shipped in v1.5.0.

This PR is a single bundle that addresses all three sets of post-merge review feedback. It's a `fix:` commit, so release-please will bump v1.5.0 → v1.5.1 (patch).

## What was wrong

### CRITICAL — `package.json.standard.template` is invalid JSON in v1.5.0
- The template carried `//` header comments, which **JSON spec doesn't allow**.
- `BE_LEAD`'s scaffold checklist (PR #9) tells the agent to `cp` the template directly. Without the comment-stripping `sed` hack that `scripts/test-templates.sh` does, the resulting `package.json` would fail `pnpm install` with a JSON parse error.
- `typia` was pinned to `^12.0.0` — that major doesn't exist; current stable is **7.x**. `pnpm install` would also fail with a 404 on resolve.
- The `{{NODE_VERSION}}` placeholder was named in the header but never used (no `engines` field).
- No `prepare: ts-patch install -s` script — typia's AOT transform won't auto-install on `pnpm install`, silently breaking `tsc --noEmit`.

### MEDIUM — `vitest.config.ts.standard.template` Windows unsafety
- `new URL("./", import.meta.url).pathname` — works on macOS/Linux, breaks on Windows. Should use `fileURLToPath` from `node:url`.

### MEDIUM — `scripts/test-templates.sh` weak checks
- Header doc claimed it ran `pnpm install` + `pnpm typecheck`; it actually only ran static checks (those steps are CI-only).
- `sed '/^\/\//d'` only stripped *line-start* comments; indented comments inside JSON would have slipped through.
- `python3 -c "..."` interpolated `$TMPDIR` directly into the heredoc → break on paths with quotes/spaces.
- `grep "UnpluginTypia"` matched on bare imports; a template that imported but never *called* `UnpluginTypia(` would have falsely passed.
- `grep "\"$dep\""` on `package.json` would false-positive when a dep name appeared in `scripts:` (e.g. `"test": "vitest run"` matched `"vitest"`).
- Static-check exit code wasn't `2` as the header documented.

### MEDIUM — `scc-build-config.md`
- Step 5: `pnpm install --no-frozen-lockfile && pnpm typecheck smoke` — the trailing `smoke` was just a description word but read as a CLI arg by an agent.
- `Write` scope contained `*.config.*` catch-all → could overwrite postcss/tailwind/etc configs outside the four template-managed files.

### MEDIUM — `scripts/verify-plugin.sh` residual `143`
- The header docstring (line 7) and the `[2/5] Agents` section title still said `143`. Bumped to `144`.

## What this PR does

### Commit `aa9762e` — PR #9 + #11 fixes
- `package.json.standard.template`: stripped `//` comments → strict JSON. typia `^12` → `^7.0.0`. Added `engines.node: ">={{NODE_VERSION}}"` and `scripts.prepare: "ts-patch install -s"`.
- `tsconfig.json.standard.template`: stripped `//` comments → strict JSON.
- `vitest.config.ts.standard.template`: `new URL().pathname` → `fileURLToPath(...)`.
- **NEW** `assets/package.json.standard.README.md`: holds the human-readable rationale that used to live in the JSON `//` comments. BE_LEAD reads this as part of the scaffold checklist; the JSON template stays strict.
- `scripts/test-templates.sh`: header now matches behavior (static only). Removed `sed` strip step (templates are valid JSON now). Python heredocs pass paths via `sys.argv[1]`. UnpluginTypia check requires both import AND call. JSON-aware dep check via `python3 -c "json.load(...).dependencies"`. tsconfig plugin check parses JSON looking for `transform: typia/lib/transform`. Static-fail exit code 2.
- `.github/workflows/ci.yml` `template-build` job: removed the now-unneeded `sed` strip.

### Commit `0f895b5` — PR #12 fixes
- `scc-build-config.md` step 5: removed standalone `smoke` word.
- `scc-build-config.md` allowed_scope.Write: tightened from `*.config.*` to the four template-managed files.
- `scripts/verify-plugin.sh`: residual `143` → `144`. Asset count `find` filter `*.template` → `*template*` to cover both `*.template` (most files) and `docker-compose.template.yml`-style naming, and to exclude the new `README.md` sibling.

## Local verification

```
$ bash scripts/verify-plugin.sh
Pass: 50  Fail: 0  ✓ All verification checks passed.

$ bash scripts/test-templates.sh
Pass: 17  Fail: 0  ✓ Template static checks passed.
```

## What this DOESN'T do

- Does not address the CodeRabbit reviews — they never landed (rate-limited on PR #11 + #12, "Review failed" on #9 because PR closed too fast).
- Does not change the v1.5.0 release notes — the release stays as cut. v1.5.1 will note these as a follow-up patch.

## Lesson learned

`gh pr view N --comments` and `gh api /repos/.../pulls/N/comments` need to be part of the merge checklist, not just CI green. Admin-merge bypasses the social signal of "wait for human approval" — the reviewer bots' comments are the only review you get.

Refs:
- PR #9 review: gemini-code-assist (1 critical + 1 high + 3 medium), chatgpt-codex (1 P1)
- PR #11 review: gemini-code-assist (5 medium), chatgpt-codex (1 P1 + 1 P2)
- PR #12 review: gemini-code-assist (3 medium)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Node.js 버전을 22로 업데이트하여 최신 런타임 지원 개선
  * 프로젝트 템플릿 유효성 검사를 강화하여 빌드 안정성 향상
  * 설정 파일 정리 및 표준화로 일관성 개선
  * CI/CD 워크플로우 및 검증 프로세스 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->