### PR TITLE
fix(monitors): per-monitor watermark files to end cross-monitor race

### DIFF
--- a/plugins/preview-forge/monitors/dispatch.sh
+++ b/plugins/preview-forge/monitors/dispatch.sh
@@ -42,10 +42,30 @@ fi
 
 : "${CLAUDE_PLUGIN_ROOT:=}"
 
+# Sentinel pattern (shared by watermark-using monitors; see issue #20):
+#   1. Initialize per-monitor watermark to epoch if missing (first run).
+#   2. Capture "now" in <watermark>.next BEFORE running find, so any file
+#      written between the capture and the find completion is still picked
+#      up next iteration (compared against the OLD watermark this round,
+#      the pre-find capture next round).
+#   3. Promote <watermark>.next to <watermark> AFTER find. This would
+#      otherwise be racey: a file written between find and touch would
+#      have mtime > post-find-touch time and be permanently skipped.
+#
+# Prior to this, blackboard-tail and cost-snapshot-watcher shared a single
+# runs/.last-check file — blackboard-tail never advanced it (repeat emits)
+# and cost-snapshot-watcher's advance starved blackboard-tail of events.
 case "$name" in
   blackboard-tail)
-    [ -e runs/.last-check ] || touch -t 197001010000 runs/.last-check
-    find runs -name 'blackboard.db' -newer runs/.last-check 2>/dev/null | head -1 || true
+    # Emit ALL updated blackboard.db paths (one per line = one notification
+    # each) before advancing the watermark. v1.5.2 used `| head -1` here but
+    # never advanced the watermark, so the dropped entries were re-emitted
+    # next iteration. Now that the watermark advances, truncating output
+    # would permanently lose events from concurrent runs — drop head -1.
+    [ -e runs/.last-check.blackboard ] || touch -t 197001010000 runs/.last-check.blackboard
+    touch runs/.last-check.blackboard.next
+    find runs -name 'blackboard.db' -newer runs/.last-check.blackboard 2>/dev/null || true
+    touch -r runs/.last-check.blackboard.next runs/.last-check.blackboard 2>/dev/null || true
     sleep 1
     ;;
   cost-regression)
@@ -55,13 +75,10 @@ case "$name" in
     sleep 30
     ;;
   cost-snapshot-watcher)
-    # Sentinel pattern: capture .last-check.next timestamp BEFORE find, then
-    # promote it to .last-check AFTER find. Prevents the race where a
-    # snapshot written between find and touch is permanently skipped.
-    [ -e runs/.last-check ] || touch -t 197001010000 runs/.last-check
-    touch runs/.last-check.next
-    find runs -name 'cost-snapshot.json' -newer runs/.last-check 2>/dev/null || true
-    touch -r runs/.last-check.next runs/.last-check 2>/dev/null || true
+    [ -e runs/.last-check.cost-snapshot ] || touch -t 197001010000 runs/.last-check.cost-snapshot
+    touch runs/.last-check.cost-snapshot.next
+    find runs -name 'cost-snapshot.json' -newer runs/.last-check.cost-snapshot 2>/dev/null || true
+    touch -r runs/.last-check.cost-snapshot.next runs/.last-check.cost-snapshot 2>/dev/null || true
     sleep 15
     ;;
   *)


### PR DESCRIPTION
## Summary

- Give `blackboard-tail` and `cost-snapshot-watcher` their own watermark files (`runs/.last-check.blackboard`, `runs/.last-check.cost-snapshot`) so they can advance independently
- Apply the sentinel pattern (`<w>.next` captured BEFORE find, promoted to `<w>` AFTER find via `touch -r`) symmetrically to both
- Drop `| head -1` from `blackboard-tail` — with the watermark now advancing, truncating output would permanently lose events from concurrent runs (caught by codex in R1)
- Move the sentinel pattern rationale into one shared header above the case statement (was duplicated inline)

Fixes #20. Follow-up to #19's run-scoping; the idle-path gate is untouched.

## Bug recap

`monitors/dispatch.sh` in v1.5.3 (post-#19) still shared a single `runs/.last-check` between two monitors — the v1.5.2 inline behavior preserved verbatim. Two symptoms:

| # | Symptom                                                                 | Mechanism                                                           |
|---|-------------------------------------------------------------------------|---------------------------------------------------------------------|
| 1 | `blackboard-tail` repeat-emits the same blackboard.db every iteration   | Reads the shared watermark but never writes it                     |
| 2 | `blackboard-tail` misses events between firings of `cost-snapshot-watcher` | snapshot-watcher bumps the shared watermark to "now" each round    |

Caught by gemini-code-assist (MEDIUM) and coderabbitai (MAJOR) on PR #19; deferred out of that PR's scope.

## Manual tests

```
A: blackboard-tail creates only its own watermark                     PASS
B: cost-snapshot-watcher creates only its own watermark               PASS
C: bare runs/.last-check is not written by either                     PASS
D: unchanged blackboard.db → second iter does NOT re-emit             PASS (fixes symptom #1)
E: modified blackboard.db → second iter emits                         PASS
F: cost-snapshot-watcher advance does NOT starve blackboard-tail      PASS (fixes symptom #2)
G: multiple concurrent-run blackboard.db updates → all emitted        PASS (codex R1 fix)
```

## Review trail

- Self-review on diff (scope, symmetry between two monitors, `set -u` compat)
- `codex review --base main` R1: P2 — `head -1` truncated multi-run emits once watermark started advancing → removed
- `codex review --base main` R2: clean ("no evident functional regression")
- `scripts/verify-plugin.sh`: 52/52 pass

## Migration

`runs/.last-check` and `runs/.last-check.next` files on existing users' disks become harmless orphans — no code path reads them anymore. First poll after upgrade treats all blackboard.db files as new (epoch-init watermark) and self-resolves on the second iteration. Cost-snapshot-watcher behaves identically because its pre-#20 init was also epoch.