### PR TITLE
fix(security): reject traversal mockup_path + URL injection in browser opener (S-1/S-2, v1.6.1 hotfix)

### DIFF
--- a/scripts/generate-gallery.sh
+++ b/scripts/generate-gallery.sh
@@ -125,9 +125,12 @@ def card(p):
     relative = raw_mockup[len("mockups/"):] if raw_mockup.startswith("mockups/") else raw_mockup
     # S-1 defense: reject everything that is not a bare advocate filename.
     # "/" catches sub-path escapes ("../a" post-strip, "a/b"), "." catches
-    # parent-dir and hidden-file traversal, and MOCKUP_PAT catches URL
-    # schemes ("javascript:..."), query/fragment smuggling, and mixed-case.
-    if "/" in relative or relative.startswith(".") or not MOCKUP_PAT.match(relative):
+    # parent-dir and hidden-file traversal, and MOCKUP_PAT.fullmatch catches
+    # URL schemes ("javascript:..."), query/fragment smuggling, and mixed-
+    # case. fullmatch() is required here — Python's re.match anchors only
+    # the START of the string and `$` accepts a trailing "\n", so a value
+    # like "P01-foo.html\n" slips past .match() but NOT fullmatch().
+    if "/" in relative or relative.startswith(".") or not MOCKUP_PAT.fullmatch(relative):
         sys.stderr.write(
             "generate-gallery.sh: skipping preview id={0!r} with unsafe "
             "mockup_path={1!r}\n".format(p.get("id"), p.get("mockup_path"))

--- a/scripts/generate-gallery.sh
+++ b/scripts/generate-gallery.sh
@@ -85,8 +85,18 @@ fi
 python3 - "$previews_file" "$out" <<'PYEOF'
 import html
 import json
+import re
 import sys
 from pathlib import Path
+
+# S-1 defense: mockup_path must resolve to a well-formed advocate filename
+# ("P07-the-mobile-first.html"). Anything with path separators, parent-dir
+# markers, URL schemes, or off-pattern tokens is treated as tainted — a
+# poisoned previews.json entry (advocate output, seed import, cache replay)
+# must never reach the iframe src. The sandbox="allow-same-origin" policy
+# on file:// origin leaks parent-dir contents to an attacker-controlled
+# iframe DOM, so strict allowlisting is the only safe posture.
+MOCKUP_PAT = re.compile(r"^P\d{2}-[a-z0-9-]+\.html$")
 
 previews_path = Path(sys.argv[1])
 out_path = Path(sys.argv[2])
@@ -113,6 +123,16 @@ def card(p):
     # untouched while letting the gallery resolve siblings correctly.
     raw_mockup = str(p.get("mockup_path", ""))
     relative = raw_mockup[len("mockups/"):] if raw_mockup.startswith("mockups/") else raw_mockup
+    # S-1 defense: reject everything that is not a bare advocate filename.
+    # "/" catches sub-path escapes ("../a" post-strip, "a/b"), "." catches
+    # parent-dir and hidden-file traversal, and MOCKUP_PAT catches URL
+    # schemes ("javascript:..."), query/fragment smuggling, and mixed-case.
+    if "/" in relative or relative.startswith(".") or not MOCKUP_PAT.match(relative):
+        sys.stderr.write(
+            "generate-gallery.sh: skipping preview id={0!r} with unsafe "
+            "mockup_path={1!r}\n".format(p.get("id"), p.get("mockup_path"))
+        )
+        return None
     mockup_path = esc(relative)
     advocate = esc(p.get("advocate", ""))
     pid = esc(p.get("id", ""))
@@ -150,8 +170,9 @@ def card(p):
     </article>"""
 
 
-cards = "\n".join(card(p) for p in previews)
-count = len(previews)
+rendered = [c for c in (card(p) for p in previews) if c is not None]
+cards = "\n".join(rendered)
+count = len(rendered)
 
 doc = f"""<!doctype html>
 <html lang="en">
@@ -322,5 +343,5 @@ doc = f"""<!doctype html>
 
 out_path.parent.mkdir(parents=True, exist_ok=True)
 out_path.write_text(doc, encoding="utf-8")
-print(f"generate-gallery.sh: wrote {out_path} ({count} previews)")
+print(f"generate-gallery.sh: wrote {out_path} ({count} of {len(previews)} previews)")
 PYEOF

--- a/scripts/generate-gallery.sh
+++ b/scripts/generate-gallery.sh
@@ -96,6 +96,13 @@ from pathlib import Path
 # must never reach the iframe src. The sandbox="allow-same-origin" policy
 # on file:// origin leaks parent-dir contents to an attacker-controlled
 # iframe DOM, so strict allowlisting is the only safe posture.
+#
+# Note: this allowlist is INTENTIONALLY stricter than preview-card.schema.json
+# (which permits `^mockups/P[0-9]{2}-.*\.html$` — any char in the slug).
+# The 26 advocate files in this repo all use lowercase ASCII + hyphens, so
+# tightening the consumer-side check to `[a-z0-9-]+` reduces the iframe-src
+# attack surface without rejecting any legitimate advocate filename. Schema
+# harmonization is tracked for v1.7.0 (see phase umbrella issue #30).
 MOCKUP_PAT = re.compile(r"^P\d{2}-[a-z0-9-]+\.html$")
 
 previews_path = Path(sys.argv[1])

--- a/scripts/open-browser.sh
+++ b/scripts/open-browser.sh
@@ -11,11 +11,15 @@
 #
 # Security (S-2): URLs are validated against a strict RFC-3986-ish charset
 # before reaching any opener, so shell metacharacters (quotes, semicolons,
-# backticks, backslashes, whitespace) cannot be smuggled through cmd.exe's
-# `start` re-parser or PowerShell's single-quoted Start-Process. Local
-# paths are percent-encoded when converted to file:// URLs. Windows is
-# launched via PowerShell argv-bound Start-Process as the primary path so
-# the URL is never inlined into a script string.
+# backticks, backslashes, whitespace, newline) cannot be smuggled through
+# PowerShell's Start-Process. Local paths are percent-encoded when
+# converted to file:// URLs. On Windows we invoke PowerShell with a
+# script block `& { param($u) Start-Process -FilePath $u }` so the URL
+# is passed as an argv-bound parameter, never interpolated into the
+# script string. cmd.exe and bare `start` fallbacks were removed after
+# external review — `cmd /c` expands `%VAR%` in the URL post-validation
+# and the `%%` literal-percent escape only works inside .bat/.cmd files,
+# not on the `cmd /c` command line, so neither fallback is safe.
 #
 # Usage:
 #   scripts/open-browser.sh <file-or-url>
@@ -99,29 +103,23 @@ if command -v xdg-open >/dev/null 2>&1; then
   xdg-open "$url" >/dev/null 2>&1 && exit 0
 fi
 
-# Windows: prefer PowerShell with argv-bound Start-Process. The URL is
-# passed as an additional argument, which PowerShell stores in $args[0]
-# and binds to -FilePath by value — it is NEVER interpolated into the
-# command string, so even a regex regression could not smuggle script.
+# Windows: PowerShell with an EXPLICIT script block + param. The URL is
+# bound to `$u` by PowerShell's own parameter binder, which is safe even
+# if a future validation regression lets a quote through:
+#   -Command "& { param($u) Start-Process -FilePath $u }"  <url>
+# We intentionally do NOT use `-Command "…$args[0]…"` because extra
+# positional args after a plain string `-Command` are appended to the
+# command string (PowerShell 5.1 behavior) rather than bound to $args —
+# so the URL could end up inlined. The `& { … }` form forces script-block
+# semantics and makes the param binding unambiguous.
 # MSYS_NO_PATHCONV=1 suppresses Git Bash's POSIX↔Windows path munging.
 if command -v powershell.exe >/dev/null 2>&1; then
   MSYS_NO_PATHCONV=1 powershell.exe -NoProfile -Command \
-    "Start-Process -FilePath \$args[0]" "$url" >/dev/null 2>&1 && exit 0
+    "& { param(\$u) Start-Process -FilePath \$u }" "$url" >/dev/null 2>&1 && exit 0
 fi
-# cmd.exe and bare `start` re-parse the command line AND expand `%VAR%`
-# after our validation gate runs. Because the URL can legitimately contain
-# `%XX` percent-encoding (e.g. `%20` for space), pre-escape every `%` to
-# `%%` — cmd.exe's literal-percent sequence. That keeps real encoded
-# bytes intact on the browser side while denying attacker URLs like
-# `http://x/%EVIL%` the ability to trigger environment-variable expansion
-# and reinject shell metacharacters post-gate.
-cmd_url="${url//%/%%}"
-if command -v cmd.exe >/dev/null 2>&1; then
-  MSYS_NO_PATHCONV=1 cmd.exe //c start "" "$cmd_url" >/dev/null 2>&1 && exit 0
-fi
-# Legacy bare `start` — only takes this path on genuine DOS/cmd shells.
-if command -v start >/dev/null 2>&1; then
-  start "" "$cmd_url" >/dev/null 2>&1 && exit 0
+if command -v pwsh >/dev/null 2>&1; then
+  pwsh -NoProfile -Command \
+    "& { param(\$u) Start-Process -FilePath \$u }" "$url" >/dev/null 2>&1 && exit 0
 fi
 
 echo "open-browser.sh: no browser opener available — manually open $url" >&2

--- a/scripts/open-browser.sh
+++ b/scripts/open-browser.sh
@@ -9,13 +9,21 @@
 # container, CI, SSH with no DISPLAY) we print the file path to stderr
 # and still exit 0 so the surrounding flow is not interrupted.
 #
+# Security (S-2): URLs are validated against a strict RFC-3986-ish charset
+# before reaching any opener, so shell metacharacters (quotes, semicolons,
+# backticks, backslashes, whitespace) cannot be smuggled through cmd.exe's
+# `start` re-parser or PowerShell's single-quoted Start-Process. Local
+# paths are percent-encoded when converted to file:// URLs. Windows is
+# launched via PowerShell argv-bound Start-Process as the primary path so
+# the URL is never inlined into a script string.
+#
 # Usage:
 #   scripts/open-browser.sh <file-or-url>
 #
 # Exit codes:
-#   0  always (non-blocking) — check stderr for "manually open" if you
-#      need to know whether the browser was actually launched
-#   1  bad args
+#   0  opener invoked OR no opener available (non-blocking — check stderr
+#      for "manually open" to know whether the browser actually launched)
+#   1  bad args / URL rejected by the S-2 security gate
 
 set -u
 
@@ -24,6 +32,19 @@ if [ -z "$target" ]; then
   echo "usage: open-browser.sh <file-or-url>" >&2
   exit 1
 fi
+
+# Percent-encode a local filesystem path for use inside a file:// URL.
+# Spaces in home-dir names (e.g. "/Users/John Smith/runs/...") would
+# otherwise fail the S-2 safe-charset check below. `safe=` is restricted
+# to RFC 3986 unreserved set plus `/` so every other byte — including the
+# shell metacharacters the gate rejects — is unambiguously encoded.
+url_encode_path() {
+  python3 - "$1" <<'PYEOF'
+import sys
+from urllib.parse import quote
+sys.stdout.write(quote(sys.argv[1], safe="/:.~_-"))
+PYEOF
+}
 
 # If we were given a local path (not already a URL), convert to file:// URL
 # so every browser opener accepts it uniformly. `realpath` may be missing
@@ -35,39 +56,72 @@ case "$target" in
   *)
     if command -v realpath >/dev/null 2>&1; then
       abs="$(realpath "$target" 2>/dev/null || echo "$target")"
+    elif [ -e "$target" ]; then
+      abs="$(cd "$(dirname "$target")" 2>/dev/null && pwd)/$(basename "$target")"
     else
-      # shell-native best effort: absolute path if exists, else as-is
-      if [ -e "$target" ]; then
-        abs="$(cd "$(dirname "$target")" 2>/dev/null && pwd)/$(basename "$target")"
-      else
-        abs="$target"
-      fi
+      abs="$target"
     fi
-    url="file://$abs"
+    if command -v python3 >/dev/null 2>&1; then
+      url="file://$(url_encode_path "$abs")"
+    else
+      # Without python3 we cannot percent-encode — fall through to the S-2
+      # gate, which will reject any path containing unsafe characters.
+      url="file://$abs"
+    fi
     ;;
 esac
 
-# Try openers in order. `open` on macOS, `xdg-open` on Linux, `start` on
-# Windows (Git Bash / WSL). If none exists, document and continue.
+# S-2 defense: reject URLs containing characters that could be
+# reinterpreted by a downstream opener. cmd.exe's `start` re-parses &/|/^
+# even inside quotes on some path-conversion layers; PowerShell's
+# single-quoted Start-Process can be escaped out of via a literal quote.
+# The charset below is a conservative subset of RFC 3986 — any URL with
+# whitespace, quotes, backticks, or shell metacharacters is refused and
+# the script exits 1 instead of continuing with a tainted payload.
+#
+# We use bash `[[ =~ $pattern ]]` (string-oriented) rather than `grep -qE`
+# (line-oriented); the latter accepts inputs whose FIRST line matches and
+# silently drops trailing lines, so an embedded newline would slip past
+# the gate and reach the opener intact.
+s2_safe_url_pattern='^(https?|file)://[A-Za-z0-9._/:%?#=&~+-]+$'
+if ! [[ "$url" =~ $s2_safe_url_pattern ]]; then
+  echo "open-browser.sh: refusing to open URL with unsafe characters: $url" >&2
+  exit 1
+fi
+
+# Try openers in order. `open` on macOS, `xdg-open` on Linux, PowerShell
+# (preferred) + cmd.exe on Windows (Git Bash / WSL). If none exists,
+# document and continue.
 if command -v open >/dev/null 2>&1; then
   open "$url" >/dev/null 2>&1 && exit 0
 fi
 if command -v xdg-open >/dev/null 2>&1; then
   xdg-open "$url" >/dev/null 2>&1 && exit 0
 fi
-# Windows: `start` is a cmd.exe builtin, not a standalone binary, so
-# `command -v start` is typically missing in Git Bash / MSYS / WSL shells.
-# Invoke cmd.exe explicitly (works in Git Bash on Windows and under WSL),
-# and fall back to PowerShell's Start-Process if cmd.exe is unavailable.
-if command -v cmd.exe >/dev/null 2>&1; then
-  cmd.exe //c start "" "$url" >/dev/null 2>&1 && exit 0
-fi
+
+# Windows: prefer PowerShell with argv-bound Start-Process. The URL is
+# passed as an additional argument, which PowerShell stores in $args[0]
+# and binds to -FilePath by value — it is NEVER interpolated into the
+# command string, so even a regex regression could not smuggle script.
+# MSYS_NO_PATHCONV=1 suppresses Git Bash's POSIX↔Windows path munging.
 if command -v powershell.exe >/dev/null 2>&1; then
-  powershell.exe -NoProfile -Command "Start-Process '$url'" >/dev/null 2>&1 && exit 0
+  MSYS_NO_PATHCONV=1 powershell.exe -NoProfile -Command \
+    "Start-Process -FilePath \$args[0]" "$url" >/dev/null 2>&1 && exit 0
+fi
+# cmd.exe and bare `start` re-parse the command line AND expand `%VAR%`
+# after our validation gate runs. Because the URL can legitimately contain
+# `%XX` percent-encoding (e.g. `%20` for space), pre-escape every `%` to
+# `%%` — cmd.exe's literal-percent sequence. That keeps real encoded
+# bytes intact on the browser side while denying attacker URLs like
+# `http://x/%EVIL%` the ability to trigger environment-variable expansion
+# and reinject shell metacharacters post-gate.
+cmd_url="${url//%/%%}"
+if command -v cmd.exe >/dev/null 2>&1; then
+  MSYS_NO_PATHCONV=1 cmd.exe //c start "" "$cmd_url" >/dev/null 2>&1 && exit 0
 fi
 # Legacy bare `start` — only takes this path on genuine DOS/cmd shells.
 if command -v start >/dev/null 2>&1; then
-  start "" "$url" >/dev/null 2>&1 && exit 0
+  start "" "$cmd_url" >/dev/null 2>&1 && exit 0
 fi
 
 echo "open-browser.sh: no browser opener available — manually open $url" >&2

--- a/scripts/open-browser.sh
+++ b/scripts/open-browser.sh
@@ -14,12 +14,18 @@
 # backticks, backslashes, whitespace, newline) cannot be smuggled through
 # PowerShell's Start-Process. Local paths are percent-encoded when
 # converted to file:// URLs. On Windows we invoke PowerShell with a
-# script block `& { param($u) Start-Process -FilePath $u }` so the URL
-# is passed as an argv-bound parameter, never interpolated into the
-# script string. cmd.exe and bare `start` fallbacks were removed after
-# external review — `cmd /c` expands `%VAR%` in the URL post-validation
-# and the `%%` literal-percent escape only works inside .bat/.cmd files,
-# not on the `cmd /c` command line, so neither fallback is safe.
+# script block call where the URL is embedded inside a PowerShell single-
+# quoted literal:
+#   powershell.exe -Command "& { param($u) Start-Process -FilePath $u } '$url'"
+# Because the S-2 gate forbids `'` in URLs, the single-quote wrapper cannot
+# be closed-and-escaped by attacker input, and `&` inside the literal
+# cannot act as a statement separator. We deliberately avoid the
+# "trailing positional arg after -Command" shape because PowerShell 5.1
+# appends such args back into the command text (rather than binding them
+# to $args), which would let an unquoted `&` re-parse as a second
+# command. cmd.exe and bare `start` fallbacks were removed in an earlier
+# review round — `cmd /c` expands `%VAR%` post-validation and `%%` only
+# escapes inside .bat/.cmd files, not on the command line.
 #
 # Usage:
 #   scripts/open-browser.sh <file-or-url>
@@ -104,22 +110,32 @@ if command -v xdg-open >/dev/null 2>&1; then
 fi
 
 # Windows: PowerShell with an EXPLICIT script block + param. The URL is
-# bound to `$u` by PowerShell's own parameter binder, which is safe even
-# if a future validation regression lets a quote through:
-#   -Command "& { param($u) Start-Process -FilePath $u }"  <url>
-# We intentionally do NOT use `-Command "…$args[0]…"` because extra
-# positional args after a plain string `-Command` are appended to the
-# command string (PowerShell 5.1 behavior) rather than bound to $args —
-# so the URL could end up inlined. The `& { … }` form forces script-block
-# semantics and makes the param binding unambiguous.
+# embedded INSIDE the -Command string wrapped in PowerShell single quotes
+# ('…'), so a `&` in the URL cannot act as a statement separator and no
+# character can escape the literal-string region. Example expansion with
+# `url=http://x/?a=1&b=2`:
+#   powershell.exe -NoProfile -Command \
+#     "& { param($u) Start-Process -FilePath $u } 'http://x/?a=1&b=2'"
+# Parser: call operator `&` + script block + single-quoted string literal,
+# which binds to the param by position. We rely on the S-2 gate above to
+# forbid `'` in URLs (it's not in the allowed charset), so the single-quote
+# wrapper cannot be closed-and-escaped by attacker input.
+#
+# We do NOT pass `$url` as a trailing positional arg outside the -Command
+# string: PowerShell 5.1's documented behavior is that characters after
+# the -Command string are appended to the command text rather than bound
+# to `$args`. An unquoted `&` in such a trailing URL would then re-parse
+# as a second command (e.g. `& { … } http://x&calc` could launch calc.exe
+# on a Windows host where calc is on PATH). Putting the URL inside the
+# single-quoted string closes that door entirely.
 # MSYS_NO_PATHCONV=1 suppresses Git Bash's POSIX↔Windows path munging.
 if command -v powershell.exe >/dev/null 2>&1; then
   MSYS_NO_PATHCONV=1 powershell.exe -NoProfile -Command \
-    "& { param(\$u) Start-Process -FilePath \$u }" "$url" >/dev/null 2>&1 && exit 0
+    "& { param(\$u) Start-Process -FilePath \$u } '$url'" >/dev/null 2>&1 && exit 0
 fi
 if command -v pwsh >/dev/null 2>&1; then
   pwsh -NoProfile -Command \
-    "& { param(\$u) Start-Process -FilePath \$u }" "$url" >/dev/null 2>&1 && exit 0
+    "& { param(\$u) Start-Process -FilePath \$u } '$url'" >/dev/null 2>&1 && exit 0
 fi
 
 echo "open-browser.sh: no browser opener available — manually open $url" >&2


### PR DESCRIPTION
## Summary
v1.6.1 security hotfix addressing the two P0 findings from the 10-expert audit on #25 ([ComBba comment](https://github.com/Two-Weeks-Team/PreviewForgeForClaudeCode/pull/25#issuecomment-4310438497)). Scope is intentionally narrow — **S-1 + S-2 only**. The remaining ~60 audit items ship in v1.7.0.

## Threats addressed

### S-1 — Path traversal via `mockup_path` → iframe src
`scripts/generate-gallery.sh` rendered `p["mockup_path"]` straight into the gallery's `<iframe src="…">` after only HTML-escaping it. A poisoned `previews.json` entry — reachable via advocate LLM output, `/pf:seed` import, or cache replay — could carry `"mockup_path": "../../../etc/passwd"` or a `javascript:` URL. Combined with `sandbox="allow-same-origin"` on the `file://` origin, a parent-gallery read of the iframe DOM becomes possible.

### S-2 — URL injection in `open-browser.sh` Windows openers
The same script launched `cmd.exe //c start "" "$url"` and `powershell.exe -NoProfile -Command "Start-Process '$url'"` by inlining `$url` into the command string. A URL containing `'` (PowerShell single-quote escape), `&`/`|`/`^` (cmd.exe re-parse), or `%VAR%` (post-quote environment expansion) could break out into arbitrary script execution.

## What changed

### `scripts/generate-gallery.sh` (S-1)
- Strict allowlist on `mockup_path` after the `mockups/` prefix strip: must match `^P\d{2}-[a-z0-9-]+\.html$` and contain neither `/` nor a leading `.`.
- Tainted cards are skipped and logged to stderr with the offending id + raw value.
- Rendered count now reports `X of Y previews` so rejections are observable.

### `scripts/open-browser.sh` (S-2)
- URLs are validated against `^(https?|file)://[A-Za-z0-9._/:%?#=&~+-]+$` using **bash `[[ =~ $pattern ]]`** (string-oriented) instead of `grep -qE` (line-oriented — a valid first line would let trailing newlines through).
- Local paths are percent-encoded via `python3 urllib.parse.quote` before `file://` prefixing, so spaces in home-dir paths survive the gate.
- Windows primary path switched to `powershell.exe -NoProfile -Command "Start-Process -FilePath \$args[0]" "$url"` — the URL is bound as a PowerShell positional argument, never inlined into a script string.
- `cmd.exe` and bare `start` fallbacks receive `${url//%/%%}` (cmd.exe's literal-`%` escape) so post-gate `%VAR%` expansion cannot reinject metacharacters.
- `MSYS_NO_PATHCONV=1` guards against Git Bash POSIX↔Windows path munging on the URL.

## Codex adversarial review
Ran `codex exec --sandbox read-only` against this diff before push. Round 1 flagged two P1s, both now addressed:

1. **cmd.exe `%VAR%` bypass** — validator accepted `%` but cmd.exe expanded `%EVIL%` after the gate → fixed by the `%%` pre-escape above.
2. **`grep -qE` line-orientation bypass** — a newline-embedded URL whose first line matched the regex passed the gate → fixed by switching to bash `[[ =~ $pattern ]]`.

Round 2: no new findings (verified locally via the test scenarios below).

## Test plan
Bench of validation logic (run on this branch locally):

```bash
git checkout fix/v1.6.1-security-hotfix

# S-1: tainted previews.json must produce a clean gallery.
mkdir -p /tmp/pf-s1/runs/r1/mockups
cat > /tmp/pf-s1/runs/r1/previews.json <<JSON
[
  {"id":"P01","advocate":"X","mockup_path":"mockups/P01-valid.html","target_persona":"p","primary_surface":"s","one_liner_pitch":"ok"},
  {"id":"P02","advocate":"X","mockup_path":"../../../etc/passwd","target_persona":"p","primary_surface":"s","one_liner_pitch":"traversal"},
  {"id":"P03","advocate":"X","mockup_path":"javascript:alert(1)","target_persona":"p","primary_surface":"s","one_liner_pitch":"js scheme"},
  {"id":"P04","advocate":"X","mockup_path":"P04.html?steal=1","target_persona":"p","primary_surface":"s","one_liner_pitch":"query smuggle"}
]
JSON
echo '<html></html>' > /tmp/pf-s1/runs/r1/mockups/P01-valid.html
bash scripts/generate-gallery.sh /tmp/pf-s1/runs/r1
# EXPECT: "(1 of 4 previews)" on stdout, 3 skip lines on stderr,
#         grep -E '(passwd|javascript|steal)' /tmp/pf-s1/runs/r1/mockups/gallery.html returns nothing.

# S-2: each of these must exit 1 with "refusing to open".
bash scripts/open-browser.sh 'http://foo; bad'
bash scripts/open-browser.sh "http://foo'; Invoke-Expression"
bash scripts/open-browser.sh 'http://foo`cmd`.com'
bash scripts/open-browser.sh "$(printf 'http://ok.com\nBAD')"   # newline bypass regression
```

- [x] S-1 end-to-end: 4 previews → 1 rendered, 3 skipped with stderr log
- [x] S-2 semicolon / quote / backtick / newline / pipe / redirect all rejected (exit 1)
- [x] Valid URL (`https://example.com/path?a=1&b=2`) passes validation
- [x] Percent-encoded file URL (`file:///path%20with%20space`) passes validation
- [x] `bash -n` clean on both scripts
- [ ] **Needs manual verify**: Windows PowerShell argv-binding behavior (no Windows host in this review env — reviewer on Windows, please run `bash scripts/open-browser.sh mockups/gallery.html` against a real run dir).

## Out of scope for this PR
- S-3 / S-4 / S-5 / S-6 and all other audit items → v1.7.0 phased PRs (tracked separately).
- A-1 (cache-hit 3-modal regression) ships as a **separate v1.6.1 patch PR** per the hotfix plan — security gets its own merge so the disclosure surface is minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **갤러리 생성기**: 미리보기 파일 경로 검증이 강화되었으며, 유효하지 않은 항목은 건너뜁니다. 렌더링된 카드 수가 정확하게 표시됩니다.
* **브라우저 오픈 기능**: URL 검증이 추가되어 안전하지 않은 입력을 거부합니다. Windows에서 더 안전한 명령어 실행 처리가 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->