### PR TITLE
test(v1.7.0): Phase 3 Part A Test & CI — T-1 / T-4 / T-6 / T-9.2 / T-9.5 / T-10 / T-11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,14 @@ jobs:
           [[ "$DEFAULT" == "standard" ]] || { echo "FAIL: defaultProfile expected 'standard', got '$DEFAULT'"; exit 1; }
           echo "✓ settings.json defaultProfile = standard"
 
+      - name: Fixture suites (Phase 1 security + Phase 3 T-4/T-6/T-9.2, v1.7.0+)
+        run: |
+          # jsonschema already installed a few steps up; the fixtures
+          # now fail-closed on missing dependency so this must stay in
+          # the same job that pip-installs it.
+          bash tests/fixtures/security/verify-security.sh
+          bash tests/fixtures/rule9-fp-guard/verify-rule9.sh
+
   test-hooks:
     name: Test hooks (unit)
     runs-on: ubuntu-latest
@@ -453,6 +461,15 @@ jobs:
             fi
             echo "✓ $dept: $count/$exp"
           done
+
+      - name: All 26 advocates reference idea.spec.json (v1.7.0+ T-1)
+        run: |
+          COUNT=$(grep -l "idea\.spec\.json" plugins/preview-forge/agents/ideation/advocates/P*.md | wc -l | tr -d ' ')
+          if [[ "$COUNT" -ne 26 ]]; then
+            echo "::error::Expected 26 advocates referencing idea.spec.json, got $COUNT"
+            exit 1
+          fi
+          echo "✓ 26/26 advocates reference idea.spec.json"
 
       - name: Check all agents use Opus 4.7
         run: |

--- a/plugins/preview-forge/hooks/cost-regression.py
+++ b/plugins/preview-forge/hooks/cost-regression.py
@@ -37,7 +37,7 @@ def load_profile(name: str) -> dict | None:
     if not p.exists():
         return None
     try:
-        return json.load(p.open())
+        return json.load(p.open(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
 
@@ -46,12 +46,12 @@ def load_active_profile(run_dir: Path) -> dict | None:
     """Priority: run_dir/.profile → env PF_PROFILE → settings.defaultProfile → 'pro'."""
     marker = run_dir / ".profile"
     if marker.exists():
-        name = marker.read_text().strip()
+        name = marker.read_text(encoding="utf-8").strip()
     else:
         name = os.environ.get("PF_PROFILE")
         if not name and SETTINGS_PATH.exists():
             try:
-                s = json.load(SETTINGS_PATH.open())
+                s = json.load(SETTINGS_PATH.open(encoding="utf-8"))
                 name = s.get("pf", {}).get("defaultProfile", "pro")
             except (OSError, json.JSONDecodeError):
                 name = "pro"
@@ -65,7 +65,7 @@ def load_snapshot(run_dir: Path) -> dict | None:
     if not snap.exists():
         return None
     try:
-        return json.load(snap.open())
+        return json.load(snap.open(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
 

--- a/plugins/preview-forge/hooks/escalation-ledger.py
+++ b/plugins/preview-forge/hooks/escalation-ledger.py
@@ -126,7 +126,7 @@ def load_ledger() -> list[dict]:
     if not LEDGER_FILE.exists():
         return []
     try:
-        data = json.loads(LEDGER_FILE.read_text())
+        data = json.loads(LEDGER_FILE.read_text(encoding="utf-8"))
         if isinstance(data, list):
             return data
     except (OSError, json.JSONDecodeError):
@@ -135,11 +135,33 @@ def load_ledger() -> list[dict]:
 
 
 def save_ledger(rows: list[dict]) -> None:
+    """Atomic write via unique NamedTemporaryFile + os.replace.
+
+    T-11 (v1.7.0+): the pre-v1.7.0 implementation wrote to the fixed
+    ``escalation-history.tmp`` name. Two writers that slipped past the
+    advisory flock (e.g. on a host where fcntl is absent — see
+    ``_lockfile``'s Windows no-op branch — or during a lock-upgrade
+    race on NFS mounts that don't fully implement POSIX advisory locks)
+    could clobber each other's tmpfile before the rename. Switching to
+    ``tempfile.NamedTemporaryFile(dir=LEDGER_DIR, delete=False)`` gives
+    every writer its own mkstemp-generated name (PID + random suffix),
+    so the atomic rename into ``escalation-history.json`` is still
+    last-writer-wins but no in-flight data is clobbered on disk.
+    """
+    import tempfile
     LEDGER_DIR.mkdir(parents=True, exist_ok=True)
-    # Write atomically via tmpfile+rename
-    tmp = LEDGER_FILE.with_suffix(".tmp")
-    tmp.write_text(json.dumps(rows, indent=2))
-    tmp.replace(LEDGER_FILE)
+    # Write to a unique tmp file, then os.replace atomically.
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=str(LEDGER_DIR),
+        prefix=".escalation-history.",
+        suffix=".tmp",
+        delete=False,
+    ) as tmp:
+        json.dump(rows, tmp, indent=2, ensure_ascii=False)
+        tmp_path = tmp.name
+    os.replace(tmp_path, str(LEDGER_FILE))
 
 
 def cmd_record(args: list[str]) -> int:

--- a/plugins/preview-forge/hooks/idea-drift-detector.py
+++ b/plugins/preview-forge/hooks/idea-drift-detector.py
@@ -110,7 +110,7 @@ def containment(reference: set[str], candidate: set[str]) -> float:
 
 def load_settings() -> dict:
     try:
-        return json.load(SETTINGS.open())
+        return json.load(SETTINGS.open(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return {}
 
@@ -130,7 +130,7 @@ def load_chosen_preview(run_root: Path) -> str:
     if not chosen.exists():
         return ""
     try:
-        data = json.load(chosen.open())
+        data = json.load(chosen.open(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return ""
     parts = [
@@ -148,7 +148,7 @@ def load_idea_spec(run_root: Path) -> dict:
     if not spec.exists():
         return {}
     try:
-        with spec.open() as f:
+        with spec.open(encoding="utf-8") as f:
             data = json.load(f)
         return data if isinstance(data, dict) else {}
     except (OSError, json.JSONDecodeError):

--- a/scripts/generate-gallery.sh
+++ b/scripts/generate-gallery.sh
@@ -60,13 +60,17 @@ MAX_FIELD = {
 }
 
 
+import html as _html
+
 def sanitize(value, max_len):
     """Allowlist-by-category for gallery-text.md (T-4 defense-in-depth):
     - drop Unicode control-category chars (keep ASCII space)
-    - strip HTML angle brackets so `<script>` payloads can't sit raw in a
-      file that a user might open in a markdown-previewer or paste into
-      a chat that renders HTML (terminal cat is fine either way, but
-      we're cheap here)
+    - HTML-escape angle brackets so `<script>` payloads can't sit raw in
+      a file that a user might open in a markdown-previewer or paste
+      into a chat that renders HTML. Terminal cat is fine either way;
+      markdown previewers see inert `&lt;…&gt;`. Uses html.escape with
+      quote=False to preserve comparison chars in legitimate pitch
+      text like "SaaS >$1M clients" → "SaaS &gt;$1M clients".
     - collapse whitespace runs
     - cap length per field
     """
@@ -75,7 +79,7 @@ def sanitize(value, max_len):
         ch for ch in s
         if ch == " " or unicodedata.category(ch)[0] != "C"
     )
-    s = s.replace("<", "").replace(">", "")
+    s = _html.escape(s, quote=False)
     s = " ".join(s.split())
     return s[:max_len]
 

--- a/scripts/generate-gallery.sh
+++ b/scripts/generate-gallery.sh
@@ -61,13 +61,21 @@ MAX_FIELD = {
 
 
 def sanitize(value, max_len):
-    """Allowlist-by-category: drop Unicode control chars (except space),
-    collapse whitespace runs, cap length."""
+    """Allowlist-by-category for gallery-text.md (T-4 defense-in-depth):
+    - drop Unicode control-category chars (keep ASCII space)
+    - strip HTML angle brackets so `<script>` payloads can't sit raw in a
+      file that a user might open in a markdown-previewer or paste into
+      a chat that renders HTML (terminal cat is fine either way, but
+      we're cheap here)
+    - collapse whitespace runs
+    - cap length per field
+    """
     s = str(value or "")
     s = "".join(
         ch for ch in s
         if ch == " " or unicodedata.category(ch)[0] != "C"
     )
+    s = s.replace("<", "").replace(">", "")
     s = " ".join(s.split())
     return s[:max_len]
 

--- a/scripts/standard-schema-lint.py
+++ b/scripts/standard-schema-lint.py
@@ -64,7 +64,7 @@ def lint_sql_files(search_root: Path) -> list[tuple[int, str, str, str]]:
     pg_cast_pattern = re.compile(r"::(?:tsvector|jsonb|uuid|interval)")
     for sql_file in migrations_dir.rglob("*.sql"):
         try:
-            content = sql_file.read_text()
+            content = sql_file.read_text(encoding="utf-8")
         except OSError:
             continue
         for match in pg_cast_pattern.finditer(content):
@@ -87,7 +87,7 @@ def lint(schema_path: Path) -> int:
         print(f"schema not found: {schema_path}", file=sys.stderr)
         return 2
 
-    content = schema_path.read_text()
+    content = schema_path.read_text(encoding="utf-8")
     lines = content.splitlines()
 
     violations_found = []

--- a/tests/fixtures/security/poisoned-previews-xss.json
+++ b/tests/fixtures/security/poisoned-previews-xss.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "P01",
+    "advocate": "<script>alert('advocate-xss')</script>",
+    "target_persona": "<img src=x onerror=alert('persona')>",
+    "primary_surface": "Web PWA",
+    "one_liner_pitch": "pitch with <script>document.cookie</script> embedded — gallery HTML generator must html.escape every field before interpolating into the iframe card template. If <script> survives to the generated gallery.html, an opener that treats file:// as trusted would execute it.",
+    "spec_alignment_notes": "T-4 (v1.7.0+ Phase 3) XSS fixture: every advocate-controlled string is html-escape-tested.",
+    "mockup_path": "mockups/P01-the-contrarian.html"
+  },
+  {
+    "id": "P02",
+    "advocate": "javascript:alert(1)//",
+    "target_persona": "\"><svg/onload=alert('persona-svg')>",
+    "primary_surface": "CLI",
+    "one_liner_pitch": "ok pitch",
+    "spec_alignment_notes": "Double-quote break-out attempt + SVG onload payload.",
+    "mockup_path": "mockups/P02-the-ops-veteran.html"
+  }
+]

--- a/tests/fixtures/security/verify-security.sh
+++ b/tests/fixtures/security/verify-security.sh
@@ -88,10 +88,16 @@ if ! grep -q '&lt;script&gt;' "$gallery_html"; then
   fail "gallery.html did not escape <script> payload — html.escape didn't run?"
   xss_leaks=$((xss_leaks + 1))
 fi
-# gallery-text.md: sanitize() strips `<` and `>` entirely from every
-# field so a paste into any markdown previewer stays inert.
-if grep -Fq '<script>' "$text_md" || grep -Fq '<svg' "$text_md" || grep -Fq '<img' "$text_md"; then
-  fail "gallery-text.md leaked raw HTML brackets into sanitised output"
+# gallery-text.md: sanitize() html-escapes `<` and `>` (to `&lt;`/`&gt;`)
+# so a paste into any markdown previewer renders inert. Legitimate
+# comparison text like "SaaS >$1M" survives as "SaaS &gt;$1M".
+if grep -Fq '<script' "$text_md" || grep -Fq '<svg' "$text_md" || grep -Fq '<img' "$text_md"; then
+  fail "gallery-text.md leaked raw < tag into sanitised output"
+  xss_leaks=$((xss_leaks + 1))
+fi
+# Positive check: the raw payload was transformed (not just dropped).
+if ! grep -Fq '&lt;script&gt;' "$text_md"; then
+  fail "gallery-text.md did not html-escape <script> payload — sanitize silently dropped content?"
   xss_leaks=$((xss_leaks + 1))
 fi
 if [[ "$xss_leaks" -eq 0 ]]; then
@@ -187,10 +193,20 @@ rm -rf "$tmp_t6"
 echo
 echo "[T-9.2] preview-cache Korean UTF-8 key"
 utf8_key=$(bash "$REPO_ROOT/scripts/preview-cache.sh" key "한글 아이디어 테스트" pro 2>/dev/null || true)
-if [[ "$utf8_key" =~ ^[0-9a-f]{16,}$ ]]; then
-  pass "preview-cache.sh key on Korean idea → $utf8_key"
+# Second Korean input — content differs, so hash MUST differ (proves
+# the hasher actually consumes non-ASCII bytes, not a locale-default
+# canonicalisation that collapses them).
+utf8_key_b=$(bash "$REPO_ROOT/scripts/preview-cache.sh" key "다른 한국어 아이디어" pro 2>/dev/null || true)
+# Known-good ASCII baseline for shape comparison.
+ascii_key=$(bash "$REPO_ROOT/scripts/preview-cache.sh" key "english baseline idea" pro 2>/dev/null || true)
+if ! [[ "$utf8_key" =~ ^[0-9a-f]{16,}$ ]]; then
+  fail "preview-cache Korean hash not hex: '$utf8_key'"
+elif [[ "$utf8_key" == "$utf8_key_b" ]]; then
+  fail "preview-cache Korean hash collapsed across distinct inputs (locale canon?)"
+elif [[ "$utf8_key" == "$ascii_key" ]]; then
+  fail "preview-cache Korean hash == ASCII-baseline hash (non-ASCII ignored?)"
 else
-  fail "preview-cache.sh key on Korean idea returned non-hex: '$utf8_key'"
+  pass "preview-cache.sh key on Korean idea: $utf8_key (!= ASCII $ascii_key · !=2nd Korean $utf8_key_b)"
 fi
 
 # ----- S-5 : ledger symlink refusal --------------------------------------

--- a/tests/fixtures/security/verify-security.sh
+++ b/tests/fixtures/security/verify-security.sh
@@ -46,6 +46,59 @@ for fixture in poisoned-previews-traversal.json poisoned-previews-url-scheme.jso
   rm -rf "$tmp_run"
 done
 
+# ----- T-4 : generate-gallery XSS escape (Phase 3 Test & CI) ----------
+echo
+echo "[T-4] generate-gallery XSS escape"
+tmp_xss="$(mktemp -d -t pf-t4-xss-XXXXXX)"
+mkdir -p "$tmp_xss/mockups"
+cp "$FIXTURES_DIR/poisoned-previews-xss.json" "$tmp_xss/previews.json"
+# Matching mockup HTMLs so the iframe code path is exercised.
+printf '<html><body>stub1</body></html>' > "$tmp_xss/mockups/P01-the-contrarian.html"
+printf '<html><body>stub2</body></html>' > "$tmp_xss/mockups/P02-the-ops-veteran.html"
+(cd "$REPO_ROOT" && bash scripts/generate-gallery.sh "$tmp_xss" >/dev/null 2>&1 || true)
+gallery_html="$tmp_xss/mockups/gallery.html"
+text_md="$tmp_xss/mockups/gallery-text.md"
+xss_leaks=0
+# gallery.html: must never contain active HTML elements / handlers.
+# Literal text payloads inside escaped nodes are fine (html.escape
+# converts `<` to `&lt;`, `"` to `&quot;`); what we care about is a
+# RAW `<script>` tag or `on[handler]=` attribute surviving.
+# Only RAW (unescaped) element openings count as XSS.
+# `&lt;img src=x onerror=…&gt;` is literal escaped text in a node body
+# and cannot execute; `<img src=x onerror=…>` would.
+# generate-gallery.sh's own HTML template uses: <article>, <span>,
+# <h2>, <p>, <a>, <iframe class="mockup" src=mockup_path …>. None of
+# the advocate-controlled fields land inside a URL attribute (iframe
+# src comes from MOCKUP_PAT-validated mockup_path only). So the raw
+# presence of any of <script / <img / <svg / <iframe-with-foreign-src
+# indicates either template drift or an escape bypass.
+if grep -Fq '<script' "$gallery_html"; then
+  fail "gallery.html contains raw <script ...> opening"
+  xss_leaks=$((xss_leaks + 1))
+fi
+# Raw <img or <svg would mean an advocate field slipped past
+# html.escape — should never happen.
+if grep -qE '<(img|svg)\b' "$gallery_html"; then
+  fail "gallery.html contains raw <img/<svg (not from template)"
+  xss_leaks=$((xss_leaks + 1))
+fi
+# Positive check: at least one payload must be escaped (proves
+# html.escape actually ran over the field).
+if ! grep -q '&lt;script&gt;' "$gallery_html"; then
+  fail "gallery.html did not escape <script> payload — html.escape didn't run?"
+  xss_leaks=$((xss_leaks + 1))
+fi
+# gallery-text.md: sanitize() strips `<` and `>` entirely from every
+# field so a paste into any markdown previewer stays inert.
+if grep -Fq '<script>' "$text_md" || grep -Fq '<svg' "$text_md" || grep -Fq '<img' "$text_md"; then
+  fail "gallery-text.md leaked raw HTML brackets into sanitised output"
+  xss_leaks=$((xss_leaks + 1))
+fi
+if [[ "$xss_leaks" -eq 0 ]]; then
+  pass "poisoned-previews-xss.json — no active script / on*= / raw HTML brackets in either artifact"
+fi
+rm -rf "$tmp_xss"
+
 # ----- S-3 : schema caps --------------------------------------------------
 echo
 echo "[S-3] idea-spec.schema.json maxLength / maxItems"
@@ -70,6 +123,75 @@ try:
 except jsonschema.ValidationError as e:
     print(f"  ✓ malicious-constraints.json — schema rejected ({e.validator} on {list(e.absolute_path)[:3]})")
 PY
+
+# ----- T-6 : open-browser.sh fake-PATH shim (Phase 3 Test & CI) ---------
+echo
+echo "[T-6] open-browser fake-PATH shim"
+tmp_t6="$(mktemp -d -t pf-t6-shim-XXXXXX)"
+mkdir -p "$tmp_t6/fake-bin"
+# Minimal xdg-open stub that records its argv to a file so we can
+# assert what open-browser.sh actually invoked.
+cat > "$tmp_t6/fake-bin/xdg-open" <<'SHIM'
+#!/bin/sh
+printf '%s\n' "$1" > "${XDG_OPEN_LOG:-/tmp/xdg-open-called.log}"
+exit 0
+SHIM
+chmod +x "$tmp_t6/fake-bin/xdg-open"
+target_html="$tmp_t6/gallery.html"
+printf '<!doctype html><html><body>stub</body></html>' > "$target_html"
+
+# Strip macOS-provided `open` and any real `xdg-open` so the fake is
+# first. `command -v open` must fail for the test to exercise the
+# xdg-open branch.
+t6_path="$tmp_t6/fake-bin:/usr/bin:/bin"
+t6_log="$tmp_t6/xdg-open.log"
+rc=0
+PATH="$t6_path" XDG_OPEN_LOG="$t6_log" \
+  bash "$REPO_ROOT/scripts/open-browser.sh" "$target_html" >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  # On macOS, /usr/bin/open still exists even with stripped PATH; skip
+  # the shim assertion then but at least confirm exit was 0 or 3 (non
+  # fatal per A-5). Exit 1 would mean S-2 URL gate misfired.
+  if [[ "$rc" -eq 1 ]]; then
+    fail "open-browser.sh exit=1 on a valid local file (S-2 gate misfire?)"
+  else
+    pass "T-6 skipped shim assertion — host has \`open\`; exit=$rc is A-5-non-fatal"
+  fi
+elif [[ ! -f "$t6_log" ]]; then
+  # No log → open-browser picked a non-xdg-open opener first
+  pass "T-6 skipped shim assertion — \`open\` or other opener won before xdg-open"
+else
+  captured=$(cat "$t6_log")
+  case "$captured" in
+    file:///*)
+      pass "T-6 xdg-open received file:// URL as expected: $captured"
+      ;;
+    *)
+      fail "T-6 xdg-open received non-file:// URL: $captured"
+      ;;
+  esac
+fi
+
+# S-2 URL gate: injection payload must exit 1.
+rc=0
+PATH="$t6_path" XDG_OPEN_LOG="$t6_log" \
+  bash "$REPO_ROOT/scripts/open-browser.sh" "http://evil.example/';alert(1);//" >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 1 ]]; then
+  pass "T-6 S-2 URL gate rejected injection payload (exit 1)"
+else
+  fail "T-6 S-2 URL gate accepted injection payload (exit=$rc, expected 1)"
+fi
+rm -rf "$tmp_t6"
+
+# ----- T-9.2 : preview-cache Korean UTF-8 hash ---------------------------
+echo
+echo "[T-9.2] preview-cache Korean UTF-8 key"
+utf8_key=$(bash "$REPO_ROOT/scripts/preview-cache.sh" key "한글 아이디어 테스트" pro 2>/dev/null || true)
+if [[ "$utf8_key" =~ ^[0-9a-f]{16,}$ ]]; then
+  pass "preview-cache.sh key on Korean idea → $utf8_key"
+else
+  fail "preview-cache.sh key on Korean idea returned non-hex: '$utf8_key'"
+fi
 
 # ----- S-5 : ledger symlink refusal --------------------------------------
 echo


### PR DESCRIPTION
Partial close on umbrella #32 (v1.7.0 Phase 3 — Test & CI Coverage). 7 of 12 items shipped here; 5 items deferred to Phase 3 Part B (a separate PR tracked below).

## Summary

| Item | File(s) | What |
|---|---|---|
| **T-1** | `.github/workflows/ci.yml` | 4-LOC step in agent-counts job: `grep -l idea.spec.json advocates/P*.md \| wc -l` must equal 26. |
| **T-4** | `scripts/generate-gallery.sh`, `tests/fixtures/security/poisoned-previews-xss.json` | New poisoned-previews fixture (`<script>`, `<img onerror>`, `<svg onload>`, `javascript:`, quote-break payloads). TEXT_PY `sanitize()` gains `html.escape(s, quote=False)` so gallery-text.md stays inert under any markdown previewer while preserving legitimate `>` / `<` in pitch text. verify-security.sh asserts no raw `<script / <img / <svg` in gallery.html, that `&lt;script&gt;` IS present (proves escape ran), and the same for the text fallback. |
| **T-6** | `tests/fixtures/security/verify-security.sh` | Fake-PATH xdg-open shim test: prepend a stub that logs its argv, assert open-browser feeds it a `file:///…` URL OR that a native opener took precedence (macOS). Also asserts the S-2 URL-injection payload still exits 1. |
| **T-9.2** | `tests/fixtures/security/verify-security.sh` | preview-cache Korean UTF-8 hash — now hashes two distinct Korean inputs + one ASCII baseline and asserts `A != B` + `A != ASCII` so a future locale-canonicalisation regression flips the test red. |
| **T-9.5** | (no code change) | Verified that the existing S-1 MOCKUP_PAT.fullmatch coerces JSON-null `mockup_path` into the string "None" which fails the regex and is skipped. Noted in PR body. |
| **T-10** | `plugins/preview-forge/hooks/{cost-regression,idea-drift-detector,escalation-ledger}.py` + `scripts/standard-schema-lint.py` | Systematic `encoding="utf-8"` on every `.open()` / `.read_text()` / `json.load(…open())` call across the 4 scope files. |
| **T-11** | `plugins/preview-forge/hooks/escalation-ledger.py` | save_ledger switches from the fixed `.tmp` suffix to `tempfile.NamedTemporaryFile(dir=LEDGER_DIR, prefix=…, delete=False, encoding="utf-8")` + `os.replace`. Two concurrent writers past the flock can no longer clobber each other's in-flight tmp bytes. Paired with `ensure_ascii=False` in `json.dump` so non-ASCII run_ids stay readable. |

CI plumbing: new step `Fixture suites (Phase 1 security + Phase 3 …)` in the `verify-plugin` job runs `tests/fixtures/security/verify-security.sh` + `tests/fixtures/rule9-fp-guard/verify-rule9.sh` on every PR.

## Deferred to Phase 3 Part B (follow-up PR, same umbrella #32)

- **T-2** `scripts/compute-filled-ratio.py` + 3-case CI fixture
- **T-3** `scripts/normalize-constraints.py` + schema `type` enum (regulatory/budget/latency/team_size/data_residency/platform/other)
- **T-5** `preview-cache.sh` 3rd-arg routing test (json-path vs integer vs numeric-file-trap R6)
- **T-7** `tests/e2e/mock-bootstrap.sh` (~100-LOC claude CLI stub)
- **T-8** LESSON 0.7 regression fixture (requires T-7 e2e harness)
- **T-9.1 / T-9.3 / T-9.4** preview-cache empty-input reject, >200KB stdin path, concurrent cmd_put atomic
- **T-12** Cross-platform CI matrix (ubuntu / macos / windows)

Rationale for split: T-2 / T-3 add new scripts + schema-enum change (breaking flavor). T-5 / T-7 / T-8 require a mock-claude harness that's worth reviewing on its own. T-12 requires Windows bash-compat audit of every existing job. Bundling all 12 would balloon the PR past what coderabbit / codex can review in one pass — the 13-comment round on #42 is fresh evidence that bigger PRs fragment reviewer attention. Shipping Part A now lets the umbrella DoD advance while the bigger scripts ship in Part B.

## Review rounds before push

- **codex R1** — 2 concerns flagged, both addressed in follow-up commit `e1e779c`:
  - `sanitize()` hard-strip of `<`/`>` would silently drop legitimate pitch content like "SaaS >$1M". Swapped to `html.escape(s, quote=False)` so comparison chars survive as `&lt;`/`&gt;`.
  - T-9.2 hex-only check could pass on a locale-canonicalised hash. Extended to 3 inputs with pairwise inequality assertion.
- **Local smoke** — verify-plugin 56/0, verify-security 7-section green, verify-rule9 3/3 green.

## Test plan

- [x] `bash -n` on `scripts/generate-gallery.sh`, `scripts/open-browser.sh`, and every new fixture script
- [x] `python3 -m py_compile` on every modified hook (cost-regression, idea-drift-detector, escalation-ledger)
- [x] `bash scripts/verify-plugin.sh` — 56/0
- [x] `bash tests/fixtures/security/verify-security.sh` — 7 sections green (S-1×2 / T-4 / S-3 / T-6 / T-9.2 / S-5 / S-6)
- [x] `bash tests/fixtures/rule9-fp-guard/verify-rule9.sh` — 3/3
- [x] T-11 save_ledger unit: fresh temp dir, no `.tmp` orphans after write
- [x] T-9.2 Korean-hash inequality: A ≠ B ≠ ASCII baseline

## Related

- Umbrella: #32 (v1.7.0 Phase 3 Test & CI — 12 items; 7 here, 5 deferred to Part B)
- Audit source: [ComBba P3 comment on #25](https://github.com/Two-Weeks-Team/PreviewForgeForClaudeCode/pull/25#issuecomment-4310443113)
- Prior phases: #39 (P4), #41 (P1), #42 (P2)

Five conventional commits: 1 `test:` (T-1), 1 `style:` (T-10), 1 `feat:` (T-11), 1 `test:` (T-4+T-6+T-9.2 bundle), 1 `fix:` (codex R1 follow-up).