### PR TITLE
fix(v1.7.0): Phase 3 Part B — preview-cache hardening (T-5 / T-9.1 / T-9.3 / T-9.4)

### DIFF
--- a/scripts/preview-cache.sh
+++ b/scripts/preview-cache.sh
@@ -59,6 +59,23 @@ print(hashlib.sha256(data).hexdigest()[:16])
 cmd_key() {
   local idea="$1"
   local profile="${2:-pro}"
+  # T-9.3 (v1.7.0+): `-` sentinel pulls the idea text from stdin. Large
+  # ideas (>200KB) would blow past ARG_MAX if passed on argv on some
+  # hosts (macOS ARG_MAX ~256KB for the whole argv+env, Linux 2MB+ but
+  # still bounded). A caller that doesn't want to trust the host
+  # ARG_MAX can do `bash preview-cache.sh key - pro < idea.txt`.
+  if [[ "$idea" == "-" ]]; then
+    idea=$(cat)
+  fi
+  # T-9.1 (v1.7.0+): empty idea text is never a legitimate cache key —
+  # it would collide across every empty-idea run at the 4-field-hash
+  # level. Callers who accidentally feed `""` (unset JSON field, empty
+  # clipboard paste, etc.) get a hard exit instead of a silent cache
+  # poison.
+  if [[ -z "$idea" ]]; then
+    echo "preview-cache.sh: idea text is empty — refusing to compute cache key" >&2
+    return 2
+  fi
   # v1.6.0 arg order: 3rd = idea_spec_path (common call in /pf:new),
   # 4th = previews_override (used only with /pf:new --previews=N).
   # Back-compat shim: legacy 3-arg callers passed a bare integer as the
@@ -72,11 +89,18 @@ cmd_key() {
   local spec_path=""
   local previews_override=""
   if [[ -n "$arg3" ]]; then
-    if [[ "$arg3" == *.json || -f "$arg3" ]]; then
+    # T-5 / R6 edge case (v1.7.0+): pure integer wins over file-exists
+    # so a cwd with an incidental `./26` file can't mis-route a legacy
+    # caller's `preview-cache.sh key "<idea>" pro 26` into spec-path
+    # land. Integer form is the older call convention; surviving this
+    # trap keeps cache keys identical to pre-v1.6.0 runs that relied on
+    # previews_override, regardless of what happens to sit in the caller's
+    # cwd. The coderabbit-flagged ordering was previously the reverse.
+    if [[ "$arg3" =~ ^[0-9]+$ ]]; then
+      previews_override="$arg3"  # legacy 3-arg call (integer only)
+    elif [[ "$arg3" == *.json || -f "$arg3" ]]; then
       spec_path="$arg3"          # v1.6.0 3-arg call
       previews_override="$arg4"
-    elif [[ "$arg3" =~ ^[0-9]+$ ]]; then
-      previews_override="$arg3"  # legacy 3-arg call (integer only)
     else
       spec_path="$arg3"          # unknown token — treat as spec path, warn below
       previews_override="$arg4"
@@ -187,7 +211,15 @@ cmd_put() {
   # Duplicated content (not a symlink) keeps TTL pruning independent
   # per key and sidesteps dangling-link edge cases on Windows.
   local alias_key="${3:-}"
-  cp "$src" "$CACHE_DIR/$key.json"
+  # T-9.4 (v1.7.0+): atomic write via unique tmp-file + rename. `cp
+  # src dst` is NOT atomic — concurrent writers can produce half-written
+  # entries where an in-flight get() sees a truncated JSON. `mktemp`
+  # gives each writer a unique dotfile inside CACHE_DIR, and `mv -f`
+  # (which is rename(2) on same-FS) swaps the entry atomically.
+  local primary_tmp
+  primary_tmp=$(mktemp "$CACHE_DIR/.${key}.XXXXXX.tmp")
+  cp "$src" "$primary_tmp"
+  mv -f "$primary_tmp" "$CACHE_DIR/$key.json"
   if [[ -n "$alias_key" && "$alias_key" != "$key" ]]; then
     # Alias write is best-effort — the strong key above is the source
     # of truth. Under `set -euo pipefail`, a bare `cp` failure would
@@ -197,9 +229,14 @@ cmd_put() {
     # caller-visible-success; we log the degradation to stderr so a
     # missed alias doesn't look like a silent feature regression. The
     # next successful put recreates the alias (self-healing).
-    if cp "$src" "$CACHE_DIR/$alias_key.json" 2>/dev/null; then
+    local alias_tmp
+    if alias_tmp=$(mktemp "$CACHE_DIR/.${alias_key}.XXXXXX.tmp" 2>/dev/null) \
+       && cp "$src" "$alias_tmp" 2>/dev/null \
+       && mv -f "$alias_tmp" "$CACHE_DIR/$alias_key.json" 2>/dev/null; then
       echo "cached: $CACHE_DIR/$key.json (+weak-alias $alias_key.json)"
     else
+      # Clean up any leftover alias tmp from a failed cp.
+      [[ -n "${alias_tmp:-}" && -f "$alias_tmp" ]] && rm -f "$alias_tmp"
       echo "preview-cache.sh: weak-alias write failed for $alias_key.json (primary $key.json intact; next put will retry)" >&2
       echo "cached: $CACHE_DIR/$key.json"
     fi

--- a/scripts/preview-cache.sh
+++ b/scripts/preview-cache.sh
@@ -64,8 +64,16 @@ cmd_key() {
   # hosts (macOS ARG_MAX ~256KB for the whole argv+env, Linux 2MB+ but
   # still bounded). A caller that doesn't want to trust the host
   # ARG_MAX can do `bash preview-cache.sh key - pro < idea.txt`.
+  #
+  # Trailing-newline preservation (codex R1 on PR #45): bash command
+  # substitution strips trailing newlines, which would make two
+  # semantically-distinct stdin inputs collide on the same hash (e.g.
+  # "idea\n\n" and "idea" both canonicalize to "idea"). We append a
+  # sentinel `_` after cat and strip exactly one, so any number of
+  # trailing newlines in the real input survives into the hasher.
   if [[ "$idea" == "-" ]]; then
-    idea=$(cat)
+    idea=$(cat; echo _)
+    idea="${idea%_}"
   fi
   # T-9.1 (v1.7.0+): empty idea text is never a legitimate cache key —
   # it would collide across every empty-idea run at the 4-field-hash
@@ -216,10 +224,35 @@ cmd_put() {
   # entries where an in-flight get() sees a truncated JSON. `mktemp`
   # gives each writer a unique dotfile inside CACHE_DIR, and `mv -f`
   # (which is rename(2) on same-FS) swaps the entry atomically.
+  #
+  # PR #45 review (gemini HIGH, codex R1): two portability/hardening
+  # fixes folded in here:
+  # 1. BSD / macOS mktemp requires the `XXXXXX` placeholders to be at
+  #    the END of the template (see mktemp(1) on macOS). The previous
+  #    `.${key}.XXXXXX.tmp` form silently failed to substitute on
+  #    macOS — mktemp accepted it as a literal filename, making every
+  #    concurrent writer race on the same literal tmp path. New form
+  #    `.${key}.tmp.XXXXXX` keeps the `.tmp` infix as a cleanup marker
+  #    while honouring the BSD end-placement rule.
+  # 2. key / alias_key are defence-in-depth sanitised to
+  #    `[:alnum:]._-` so a malformed caller can't inject path separators
+  #    into the tmp path. Our own callers emit 16-hex keys only, but
+  #    the third-party weak-alias write path now has the same guarantee.
+  local safe_key safe_alias
+  safe_key=$(printf '%s' "$key" | tr -dc '[:alnum:]._-')
+  if [[ -z "$safe_key" ]]; then
+    echo "preview-cache.sh: refusing put with empty/unsafe key: '$key'" >&2
+    return 2
+  fi
   local primary_tmp
-  primary_tmp=$(mktemp "$CACHE_DIR/.${key}.XXXXXX.tmp")
-  cp "$src" "$primary_tmp"
-  mv -f "$primary_tmp" "$CACHE_DIR/$key.json"
+  primary_tmp=$(mktemp "$CACHE_DIR/.${safe_key}.tmp.XXXXXX")
+  # gemini HIGH: explicit cleanup so `set -euo pipefail` can't leave a
+  # tmp orphan if cp fails.
+  if ! cp "$src" "$primary_tmp" 2>/dev/null || ! mv -f "$primary_tmp" "$CACHE_DIR/$safe_key.json" 2>/dev/null; then
+    [[ -f "$primary_tmp" ]] && rm -f "$primary_tmp"
+    echo "preview-cache.sh: primary put failed for key '$safe_key'" >&2
+    return 1
+  fi
   if [[ -n "$alias_key" && "$alias_key" != "$key" ]]; then
     # Alias write is best-effort — the strong key above is the source
     # of truth. Under `set -euo pipefail`, a bare `cp` failure would
@@ -229,19 +262,21 @@ cmd_put() {
     # caller-visible-success; we log the degradation to stderr so a
     # missed alias doesn't look like a silent feature regression. The
     # next successful put recreates the alias (self-healing).
+    safe_alias=$(printf '%s' "$alias_key" | tr -dc '[:alnum:]._-')
     local alias_tmp
-    if alias_tmp=$(mktemp "$CACHE_DIR/.${alias_key}.XXXXXX.tmp" 2>/dev/null) \
+    if [[ -n "$safe_alias" ]] \
+       && alias_tmp=$(mktemp "$CACHE_DIR/.${safe_alias}.tmp.XXXXXX" 2>/dev/null) \
        && cp "$src" "$alias_tmp" 2>/dev/null \
-       && mv -f "$alias_tmp" "$CACHE_DIR/$alias_key.json" 2>/dev/null; then
-      echo "cached: $CACHE_DIR/$key.json (+weak-alias $alias_key.json)"
+       && mv -f "$alias_tmp" "$CACHE_DIR/$safe_alias.json" 2>/dev/null; then
+      echo "cached: $CACHE_DIR/$safe_key.json (+weak-alias $safe_alias.json)"
     else
       # Clean up any leftover alias tmp from a failed cp.
       [[ -n "${alias_tmp:-}" && -f "$alias_tmp" ]] && rm -f "$alias_tmp"
-      echo "preview-cache.sh: weak-alias write failed for $alias_key.json (primary $key.json intact; next put will retry)" >&2
-      echo "cached: $CACHE_DIR/$key.json"
+      echo "preview-cache.sh: weak-alias write failed for '$alias_key' (primary $safe_key.json intact; next put will retry)" >&2
+      echo "cached: $CACHE_DIR/$safe_key.json"
     fi
   else
-    echo "cached: $CACHE_DIR/$key.json"
+    echo "cached: $CACHE_DIR/$safe_key.json"
   fi
 }
 

--- a/tests/fixtures/security/verify-security.sh
+++ b/tests/fixtures/security/verify-security.sh
@@ -230,6 +230,17 @@ if [[ "$k_stdin" =~ ^[0-9a-f]{16,}$ && "$k_stdin" == "$k_argv" ]]; then
 else
   fail "T-9.3: stdin hash '$k_stdin' != argv hash '$k_argv'"
 fi
+# PR #45 codex R1: trailing-newline preservation — distinct inputs
+# (same semantic text, different trailing newlines) MUST yield distinct
+# hashes, AND must match argv byte-for-byte.
+k_nn=$(printf 'idea'     | bash "$REPO_ROOT/scripts/preview-cache.sh" key - pro 2>/dev/null || true)
+k_1n=$(printf 'idea\n'   | bash "$REPO_ROOT/scripts/preview-cache.sh" key - pro 2>/dev/null || true)
+k_3n=$(printf 'idea\n\n\n' | bash "$REPO_ROOT/scripts/preview-cache.sh" key - pro 2>/dev/null || true)
+if [[ "$k_nn" == "$k_1n" || "$k_1n" == "$k_3n" || "$k_nn" == "$k_3n" ]]; then
+  fail "T-9.3 stdin trailing-newline collision — 0/1/3 newlines hashed the same"
+else
+  pass "T-9.3 stdin preserves trailing newlines (0/1/3 → distinct hashes)"
+fi
 
 echo
 echo "[T-5] preview-cache 3rd-arg routing"
@@ -316,10 +327,12 @@ else
     fail "T-9.4: final SHA $final_sha matches NONE of the 5 source SHAs — atomic write broken (cross-writer byte mix)"
   fi
 fi
-# Verify no leftover .tmp files.
-leftover=$(find "$PF_CACHE_DIR" -maxdepth 1 -name '*.tmp' 2>/dev/null | wc -l | tr -d ' ')
+# Verify no leftover .tmp.XXXXXX files (PR #45 review: template now
+# uses the BSD-portable `.tmp.XXXXXX` form with X-at-end, so the infix
+# `.tmp.` is the orphan detector).
+leftover=$(find "$PF_CACHE_DIR" -maxdepth 1 -name '*.tmp.*' 2>/dev/null | wc -l | tr -d ' ')
 if [[ "$leftover" -ne 0 ]]; then
-  fail "T-9.4: $leftover .tmp orphans under $PF_CACHE_DIR"
+  fail "T-9.4: $leftover .tmp.* orphans under $PF_CACHE_DIR"
 fi
 unset PF_CACHE_DIR
 rm -rf "$tmp_put"

--- a/tests/fixtures/security/verify-security.sh
+++ b/tests/fixtures/security/verify-security.sh
@@ -209,6 +209,106 @@ else
   pass "preview-cache.sh key on Korean idea: $utf8_key (!= ASCII $ascii_key · !=2nd Korean $utf8_key_b)"
 fi
 
+# ----- T-5 / T-9.1 / T-9.3 / T-9.4 : preview-cache hardening (Phase 3 Part B) ---
+echo
+echo "[T-9.1] preview-cache reject empty idea"
+rc=0
+err=$(bash "$REPO_ROOT/scripts/preview-cache.sh" key "" pro 2>&1 >/dev/null) || rc=$?
+if [[ "$rc" -eq 2 && "$err" == *"empty"* ]]; then
+  pass "empty idea rejected with exit 2 + stderr message"
+else
+  fail "T-9.1: empty idea should exit 2, got rc=$rc stderr='$err'"
+fi
+
+echo
+echo "[T-9.3] preview-cache key via stdin (- sentinel)"
+k_stdin=$(printf 'stdin-delivered idea text that is reasonably long' \
+  | bash "$REPO_ROOT/scripts/preview-cache.sh" key - pro 2>/dev/null || true)
+k_argv=$(bash "$REPO_ROOT/scripts/preview-cache.sh" key "stdin-delivered idea text that is reasonably long" pro 2>/dev/null || true)
+if [[ "$k_stdin" =~ ^[0-9a-f]{16,}$ && "$k_stdin" == "$k_argv" ]]; then
+  pass "- sentinel reads stdin and hashes identically to argv ($k_stdin)"
+else
+  fail "T-9.3: stdin hash '$k_stdin' != argv hash '$k_argv'"
+fi
+
+echo
+echo "[T-5] preview-cache 3rd-arg routing"
+tmp_rt="$(mktemp -d -t pf-t5-routing-XXXXXX)"
+# Create a fake spec file to test the file-path branch.
+spec_file="$tmp_rt/idea.spec.json"
+printf '{"_schema_version":"1.0.0","_filled_ratio":0.5,"idea_summary":"x"}' > "$spec_file"
+cd "$tmp_rt"
+# Also create a numeric-named sibling (R6 edge case).
+touch 26
+# Baseline — no 3rd arg.
+k_none=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/preview-forge" \
+  bash "$REPO_ROOT/scripts/preview-cache.sh" key "test" pro 2>/dev/null)
+# Integer override (legacy 3-arg) — must match for both with/without ./26 trap.
+k_int=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/preview-forge" \
+  bash "$REPO_ROOT/scripts/preview-cache.sh" key "test" pro 26 2>/dev/null)
+# Spec-path 3-arg — must differ from integer + baseline.
+k_spec=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/preview-forge" \
+  bash "$REPO_ROOT/scripts/preview-cache.sh" key "test" pro "$spec_file" 2>/dev/null)
+# Unknown 3-arg (non-integer, non-existent file) — documented behaviour
+# at preview-cache.sh:~110: emit a stderr warning and fall back to the
+# 4-field baseline key (no spec hash). Captured both streams so we can
+# assert the warning is present.
+k_unknown_combined=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/preview-forge" \
+  bash "$REPO_ROOT/scripts/preview-cache.sh" key "test" pro "not-an-existing-file" 2>&1)
+k_unknown=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/preview-forge" \
+  bash "$REPO_ROOT/scripts/preview-cache.sh" key "test" pro "not-an-existing-file" 2>/dev/null)
+cd - >/dev/null
+# Repeat integer case in a clean dir without the ./26 trap for R6.
+tmp_clean=$(mktemp -d -t pf-t5-clean-XXXXXX); cd "$tmp_clean"
+k_int_clean=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/preview-forge" \
+  bash "$REPO_ROOT/scripts/preview-cache.sh" key "test" pro 26 2>/dev/null)
+cd - >/dev/null
+
+route_fails=0
+[[ "$k_none" =~ ^[0-9a-f]{16,}$ ]] || { fail "T-5 baseline (no 3rd arg) not hex"; route_fails=$((route_fails+1)); }
+[[ "$k_int" =~ ^[0-9a-f]{16,}$ && "$k_int" != "$k_none" ]] || { fail "T-5 integer branch: key same as baseline (override didn't fire)"; route_fails=$((route_fails+1)); }
+[[ "$k_spec" =~ ^[0-9a-f]{16,}$ && "$k_spec" != "$k_int" && "$k_spec" != "$k_none" ]] || { fail "T-5 spec-path branch: didn't produce distinct key"; route_fails=$((route_fails+1)); }
+[[ "$k_unknown" == "$k_none" ]] || { fail "T-5 unknown-token: did NOT fall back to baseline (spec_hash leaked?)"; route_fails=$((route_fails+1)); }
+[[ "$k_unknown_combined" == *"does not exist"* ]] || { fail "T-5 unknown-token: expected stderr warning, got '$k_unknown_combined'"; route_fails=$((route_fails+1)); }
+[[ "$k_int" == "$k_int_clean" ]] || { fail "T-5 / R6: integer key changed when ./26 trap file existed"; route_fails=$((route_fails+1)); }
+[[ "$route_fails" -eq 0 ]] && pass "T-5 routing: baseline=$k_none integer=$k_int spec=$k_spec unknown=$k_unknown; R6 trap safe"
+rm -rf "$tmp_rt" "$tmp_clean"
+
+echo
+echo "[T-9.4] preview-cache atomic cmd_put (concurrent writers)"
+tmp_put=$(mktemp -d -t pf-t9-4-XXXXXX)
+export PF_CACHE_DIR="$tmp_put/cache"
+mkdir -p "$PF_CACHE_DIR"
+# Build 5 distinct payloads so we can spot partial writes.
+for i in 1 2 3 4 5; do
+  printf '{"run":%d,"padding":"%s"}\n' "$i" "$(head -c 40000 /dev/urandom | base64 | tr -d '\n' | head -c 40000)" \
+    > "$tmp_put/src-$i.json"
+done
+# Fire 5 concurrent cmd_put to the SAME key, then verify the resulting
+# file is exactly one of the sources (not a half-written mix).
+for i in 1 2 3 4 5; do
+  ( bash "$REPO_ROOT/scripts/preview-cache.sh" put concurrent-key "$tmp_put/src-$i.json" >/dev/null 2>&1 ) &
+done
+wait
+final="$PF_CACHE_DIR/concurrent-key.json"
+if ! python3 -c "import json; json.load(open('$final'))" 2>/dev/null; then
+  fail "T-9.4: concurrent cmd_put produced corrupt JSON at $final"
+else
+  size=$(wc -c < "$final")
+  if [[ "$size" -lt 39990 || "$size" -gt 40100 ]]; then
+    fail "T-9.4: final file size $size is not close to a source (40k) — partial?"
+  else
+    pass "T-9.4: 5 concurrent puts → single valid JSON (size $size) + no leftover .tmp"
+  fi
+fi
+# Verify no leftover .tmp files.
+leftover=$(find "$PF_CACHE_DIR" -name '*.tmp' -maxdepth 1 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$leftover" -ne 0 ]]; then
+  fail "T-9.4: $leftover .tmp orphans under $PF_CACHE_DIR"
+fi
+unset PF_CACHE_DIR
+rm -rf "$tmp_put"
+
 # ----- S-5 : ledger symlink refusal --------------------------------------
 echo
 echo "[S-5] escalation-ledger _lockfile O_NOFOLLOW"

--- a/tests/fixtures/security/verify-security.sh
+++ b/tests/fixtures/security/verify-security.sh
@@ -279,13 +279,21 @@ echo "[T-9.4] preview-cache atomic cmd_put (concurrent writers)"
 tmp_put=$(mktemp -d -t pf-t9-4-XXXXXX)
 export PF_CACHE_DIR="$tmp_put/cache"
 mkdir -p "$PF_CACHE_DIR"
-# Build 5 distinct payloads so we can spot partial writes.
+# Build 5 distinct payloads with UNIQUE per-source content + pre-
+# computed SHAs so we can prove the final file equals EXACTLY one of
+# the sources (not a partial-write byte salad that happens to pass a
+# size range check).
 for i in 1 2 3 4 5; do
-  printf '{"run":%d,"padding":"%s"}\n' "$i" "$(head -c 40000 /dev/urandom | base64 | tr -d '\n' | head -c 40000)" \
+  printf '{"run":%d,"padding":"%s"}\n' "$i" \
+    "$(head -c 40000 /dev/urandom | base64 | tr -d '\n' | head -c 40000)" \
     > "$tmp_put/src-$i.json"
 done
-# Fire 5 concurrent cmd_put to the SAME key, then verify the resulting
-# file is exactly one of the sources (not a half-written mix).
+# Canonical source SHAs.
+declare -a src_shas=()
+for i in 1 2 3 4 5; do
+  src_shas+=("$(shasum -a 256 "$tmp_put/src-$i.json" | awk '{print $1}')")
+done
+# Fire 5 concurrent cmd_put to the SAME key.
 for i in 1 2 3 4 5; do
   ( bash "$REPO_ROOT/scripts/preview-cache.sh" put concurrent-key "$tmp_put/src-$i.json" >/dev/null 2>&1 ) &
 done
@@ -294,15 +302,22 @@ final="$PF_CACHE_DIR/concurrent-key.json"
 if ! python3 -c "import json; json.load(open('$final'))" 2>/dev/null; then
   fail "T-9.4: concurrent cmd_put produced corrupt JSON at $final"
 else
-  size=$(wc -c < "$final")
-  if [[ "$size" -lt 39990 || "$size" -gt 40100 ]]; then
-    fail "T-9.4: final file size $size is not close to a source (40k) — partial?"
+  final_sha=$(shasum -a 256 "$final" | awk '{print $1}')
+  matched=0
+  for sha in "${src_shas[@]}"; do
+    [[ "$final_sha" == "$sha" ]] && matched=1
+  done
+  if [[ "$matched" -eq 1 ]]; then
+    # Also size-sanity to make sure the SHA match isn't a 0-byte
+    # coincidence (mktemp empty file hashed to itself).
+    size=$(wc -c < "$final" | tr -d ' ')
+    pass "T-9.4: 5 concurrent puts → final SHA matches exactly one source (size $size, sha ${final_sha:0:12})"
   else
-    pass "T-9.4: 5 concurrent puts → single valid JSON (size $size) + no leftover .tmp"
+    fail "T-9.4: final SHA $final_sha matches NONE of the 5 source SHAs — atomic write broken (cross-writer byte mix)"
   fi
 fi
 # Verify no leftover .tmp files.
-leftover=$(find "$PF_CACHE_DIR" -name '*.tmp' -maxdepth 1 2>/dev/null | wc -l | tr -d ' ')
+leftover=$(find "$PF_CACHE_DIR" -maxdepth 1 -name '*.tmp' 2>/dev/null | wc -l | tr -d ' ')
 if [[ "$leftover" -ne 0 ]]; then
   fail "T-9.4: $leftover .tmp orphans under $PF_CACHE_DIR"
 fi


### PR DESCRIPTION
Partial close on umbrella #32 (v1.7.0 Phase 3 — Test & CI Coverage). 4 more items shipped; 11/12 total with Part A (#44) merged. Only T-2 / T-3 / T-7 / T-8 / T-12 remain, tracked as Part C (separate PR).

## Summary

All four items are edits to `scripts/preview-cache.sh` + paired fixtures in `tests/fixtures/security/verify-security.sh` (already CI-wired via the verify-plugin step added by #44).

| Item | Change |
|---|---|
| **T-9.1** `cmd_key` empty reject | `bash preview-cache.sh key "" pro` now exits 2 with a stderr message. Previously an empty idea hashed through unchanged and every empty-idea call from every profile collided on the same 4-field key. |
| **T-9.3** `cmd_key` stdin sentinel | `-` pulls the idea text from stdin (`bash preview-cache.sh key - pro < idea.txt`). ARG_MAX protection for >200KB ideas on macOS (~256KB argv+env combined). |
| **T-5 / R6** `cmd_key` integer-first routing | Reversed the 3rd-arg branch order so pure integers always become `previews_override`, regardless of whether a file with that name sits in cwd. The prior "file-exists wins" order turned a legacy call `… key "idea" pro 26` into a spec-path-with-sha-of-empty-`./26` path the moment someone happened to have a numeric-named sibling in their workspace. |
| **T-9.4** `cmd_put` atomic write | Replaced `cp src $CACHE_DIR/$key.json` with `mktemp $CACHE_DIR/.${key}.XXXXXX.tmp` + `cp` + `mv -f`. Same for the v1.6.1 A-1 weak-alias write, with tmp cleanup on failure. Two concurrent writers past the race window can no longer produce a half-written JSON that crashes `cmd_get`'s parser. |

## Test fixtures (4 new sections in verify-security.sh)

- **T-9.1** empty-idea → exit 2 + stderr "empty"
- **T-9.3** stdin hash byte-identical to argv hash
- **T-5**
  - baseline (no 3rd arg), integer override, spec-path, unknown token — each produces the expected key (distinct or documented-fallback)
  - unknown-token path emits the `does not exist` warning AND falls back to the baseline 4-field key (documented behaviour at preview-cache.sh:~110)
  - **R6** integer key is IDENTICAL with or without a `./26` trap file in cwd
- **T-9.4** 5 parallel puts with 40KB distinct sources, pre-hashed → final file's SHA-256 MUST match exactly one of the 5 source SHAs (strengthened after codex R1 — "parses as JSON + size ≈ 40KB" was too weak on its own) + no `.tmp` orphans remain

All 11 sections of verify-security.sh green; rule9-fp-guard 3/3 green; verify-plugin 56/0.

## Review rounds before push

- **codex R1** — 1 P2 flagged, fixed in follow-up commit `2436577`:
  - T-9.4 "final file is about the right size + parses as JSON" was too weak; a torn write ending in a JSON-valid boundary would slip past. Strengthened to pre-hash + post-hash SHA-256 equality against one of the 5 sources.
  - Also fixed `find -name X -maxdepth 1` → `find -maxdepth 1 -name X` for macOS/BSD find portability (side-effect of reading through the diff).
  - No other concerns on branch-order reversal, mktemp + mv semantics, or stdin-sentinel collisions.

## Deferred to Part C (same umbrella #32)

- **T-2** `scripts/compute-filled-ratio.py` + 3-case CI fixture — new standalone Python script, worth its own PR for focused review.
- **T-3** `scripts/normalize-constraints.py` + `idea-spec.schema.json` `type` enum — schema change has breaking-flavor surface area (existing idea.spec.json files with non-canonical `type` values would fail validation post-merge); want that discussion isolated.
- **T-7** `tests/e2e/mock-bootstrap.sh` (~100+ LOC claude CLI stub) — complex harness; deserves its own review.
- **T-8** LESSON 0.7 regression fixture — depends on T-7.
- **T-12** Cross-platform CI matrix (ubuntu / macos / windows) — requires auditing every existing CI job for BSD/Windows bash incompat; risky bundle.

## Test plan

- [x] `bash -n scripts/preview-cache.sh` — syntax OK
- [x] `bash scripts/verify-plugin.sh` — 56/0
- [x] `bash tests/fixtures/security/verify-security.sh` — 11 sections green
- [x] `bash tests/fixtures/rule9-fp-guard/verify-rule9.sh` — 3/3
- [x] R6 manual: key "idea" pro 26 (with file ./26) == key "idea" pro 26 (clean cwd)
- [x] T-9.4 manual: 5 parallel puts → final SHA ∈ {source_sha_1..5}

## Related

- Umbrella: #32 (v1.7.0 Phase 3 — 12 items; 7 in #44, 4 here → 11/12, T-2/T-3/T-7/T-8/T-12 in Part C)
- Prior: #39 (P4), #41 (P1), #42 (P2), #44 (P3 Part A)
- Audit: [ComBba P3 comment on #25](https://github.com/Two-Weeks-Team/PreviewForgeForClaudeCode/pull/25#issuecomment-4310443113)

Three conventional commits: 1 `fix:` (cache hardening — empty reject + stdin + R6 + atomic put), 1 `test:` (fixture assertions), 1 `test:` (R1 SHA-strengthening).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 캐시 키 생성 시 표준 입력(stdin) 지원 추가

* **버그 수정**
  * 동시 캐시 쓰기 작업의 원자성 보장으로 안정성 개선
  * 인수 파싱 순서 개선으로 잘못된 라우팅 방지
  * 빈 입력값에 대한 유효성 검사 강화

* **테스트**
  * 캐시 키 생성, 동시 쓰기, 인수 처리에 대한 포괄적 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->