### PR TITLE
refactor(v1.7.0): Phase 7 Refactoring & Code Quality (R-1 / R-3 / R-4)

### DIFF
--- a/scripts/preview-cache.sh
+++ b/scripts/preview-cache.sh
@@ -56,6 +56,45 @@ print(hashlib.sha256(data).hexdigest()[:16])
 "
 }
 
+# R-1 (v1.7.0+): Python heredoc helpers consolidate the 8+ inline blocks
+# that used to repeat the same mtime / TTL / JSON-key / sha256 patterns
+# across cmd_key / cmd_get / cmd_prune. Each helper encapsulates one
+# concern + the encoding="utf-8" requirement from T-10 in a single
+# choke point. Security note: expr arguments for py_read_json are
+# interpolated into the python source (same constraint the pre-v1.7.0
+# inline blocks had), so CALLERS MUST pass a string literal controlled
+# by this script — never user input.
+
+py_sha256_file() {
+  # Short (16-hex) sha256 of a file, used for idea_spec_hash.
+  python3 -c "
+import hashlib, sys
+print(hashlib.sha256(open(sys.argv[1], 'rb').read()).hexdigest()[:16])
+" "$1"
+}
+
+py_file_age() {
+  # Integer seconds since the file's mtime (for TTL comparison).
+  python3 -c "import os, sys, time; print(int(time.time() - os.path.getmtime(sys.argv[1])))" "$1"
+}
+
+py_read_json() {
+  # Read JSON file $1 and print `d<expr>` where <expr> is a hardcoded
+  # python subscript / method chain (e.g. "['caching']['ttl_seconds']"
+  # or ".get('profile', 'pro')"). On any exception, print $3 (fallback).
+  local file="$1"
+  local expr="$2"
+  local fallback="${3:-}"
+  python3 -c "
+import json, sys
+try:
+    d = json.load(open(sys.argv[1], encoding='utf-8'))
+    print(d${expr})
+except Exception:
+    print(sys.argv[2])
+" "$file" "$fallback"
+}
+
 cmd_key() {
   local idea="$1"
   local profile="${2:-pro}"
@@ -119,14 +158,7 @@ cmd_key() {
   # file missing, fall back to the profile name as the set discriminator.
   local advocate_count=""
   if [[ -n "$PLUGIN_ROOT" && -f "$PLUGIN_ROOT/profiles/$profile.json" ]]; then
-    advocate_count=$(python3 -c "
-import json, sys
-try:
-    p = json.load(open(sys.argv[1]))
-    print(p['previews']['count'])
-except Exception:
-    print('')
-" "$PLUGIN_ROOT/profiles/$profile.json")
+    advocate_count=$(py_read_json "$PLUGIN_ROOT/profiles/$profile.json" "['previews']['count']" "")
   fi
   # Override takes precedence if provided.
   if [[ -n "$previews_override" ]]; then
@@ -145,16 +177,25 @@ except Exception:
   # that meant to include spec would be poisonous — repeat runs with
   # different Socratic answers could share the same (pre-upgrade) cache
   # entry. The warning surfaces the mistake so the caller can fix the path.
+  # R-3 (v1.7.0+): spec-missing is now fail-fast (exit 2). ComBba
+  # independent verification proved that warn+silent-fallback collapsed
+  # three distinct 3-arg invocation shapes (spec-missing, unknown-token,
+  # legacy-2-arg) onto the same 4-field cache key, creating v1.5.x
+  # legacy-entry poisoning potential. The original CodeRabbit
+  # fail-fast recommendation is restored. Back-compat:
+  # - Legacy v1.5.x callers never passed spec_path, so this branch
+  #   never entered; they keep the 4-field keyspace.
+  # - v1.6.0+ callers that pass spec_path are required to guarantee
+  #   the file exists before calling — caller responsibility.
+  # - A-1 weak-key probe explicitly MUST NOT pass spec_path (see
+  #   ideation-lead.md §1 and commands/new.md §4).
   local spec_hash=""
   if [[ -n "$spec_path" ]]; then
-    if [[ -f "$spec_path" ]]; then
-      spec_hash=$(python3 -c "
-import hashlib, sys
-print(hashlib.sha256(open(sys.argv[1], 'rb').read()).hexdigest()[:16])
-" "$spec_path")
-    else
-      echo "preview-cache.sh: spec_path='$spec_path' does not exist — key will not include spec hash (cache may hit stale v1.5.x entry)" >&2
+    if [[ ! -f "$spec_path" ]]; then
+      echo "preview-cache.sh: spec_path='$spec_path' does not exist — refusing to emit a 4-field key that could collide with a legacy v1.5.x entry" >&2
+      return 2
     fi
+    spec_hash=$(py_sha256_file "$spec_path")
   fi
 
   if [[ -n "$spec_hash" ]]; then
@@ -177,26 +218,14 @@ cmd_get() {
   # stay safe even if PLUGIN_ROOT or cache keys ever contain odd chars.
   local ttl=0
   local profile_name
-  profile_name=$(python3 -c "
-import json, sys
-try:
-    print(json.load(open(sys.argv[1])).get('profile', 'pro'))
-except Exception:
-    print('pro')
-" "$file")
+  profile_name=$(py_read_json "$file" ".get('profile', 'pro')" "pro")
   if [[ -n "$PLUGIN_ROOT" && -f "$PLUGIN_ROOT/profiles/$profile_name.json" ]]; then
-    ttl=$(python3 -c "
-import json, sys
-try:
-    print(json.load(open(sys.argv[1]))['caching']['ttl_seconds'])
-except Exception:
-    print(0)
-" "$PLUGIN_ROOT/profiles/$profile_name.json")
+    ttl=$(py_read_json "$PLUGIN_ROOT/profiles/$profile_name.json" "['caching']['ttl_seconds']" "0")
   fi
 
   if [[ "$ttl" -gt 0 ]]; then
     local age
-    age=$(python3 -c "import os,sys,time; print(int(time.time() - os.path.getmtime(sys.argv[1])))" "$file")
+    age=$(py_file_age "$file")
     if [[ "$age" -gt "$ttl" ]]; then
       return 1
     fi
@@ -294,22 +323,10 @@ cmd_prune() {
   for f in "$CACHE_DIR"/*.json; do
     [[ -f "$f" ]] || continue
     local profile_name
-    profile_name=$(python3 -c "
-import json, sys
-try:
-    print(json.load(open(sys.argv[1])).get('profile', 'pro'))
-except Exception:
-    print('pro')
-" "$f")
+    profile_name=$(py_read_json "$f" ".get('profile', 'pro')" "pro")
     local ttl=0
     if [[ -f "$PLUGIN_ROOT/profiles/$profile_name.json" ]]; then
-      ttl=$(python3 -c "
-import json, sys
-try:
-    print(json.load(open(sys.argv[1]))['caching']['ttl_seconds'])
-except Exception:
-    print(0)
-" "$PLUGIN_ROOT/profiles/$profile_name.json")
+      ttl=$(py_read_json "$PLUGIN_ROOT/profiles/$profile_name.json" "['caching']['ttl_seconds']" "0")
     fi
     if [[ "$ttl" -eq 0 ]]; then
       rm -f "$f"
@@ -317,7 +334,7 @@ except Exception:
       continue
     fi
     local age
-    age=$(python3 -c "import os,sys,time; print(int(time.time() - os.path.getmtime(sys.argv[1])))" "$f")
+    age=$(py_file_age "$f")
     if [[ "$age" -gt "$ttl" ]]; then
       rm -f "$f"
       removed=$((removed + 1))

--- a/scripts/recommend-profile.sh
+++ b/scripts/recommend-profile.sh
@@ -78,7 +78,14 @@ fi
 # don't have POSIX word-char boundaries; false-positive risk is negligible
 # since these are multi-character distinctive terms.
 #
-# Quality-engineer pushed for explicit JP/CN stubs — empty for v1.4.0, flagged TODO.
+# R-4 (v1.7.0+, was quality-engineer TODO): JP/CN signal banks deferred
+# to v2.0+. Escalation signals here are compliance-regime specific
+# (Stripe / HIPAA / GDPR / SOC2), which have EN-native naming even in
+# KR markets; adding Japanese / Chinese banks would require translators
+# who know the LOCAL equivalent regulatory terms (個人情報保護法 / 个人
+# 信息保护法 / PIPL / APPI / etc.), not mechanical translation. This is
+# a product-scope decision, not an implementation gap — revisit when
+# Preview Forge has explicit JP or CN adoption signal from users.
 
 EN_HARD_PAYMENTS=("stripe" "pci" "subscription" "billing flow" "payment processing")
 EN_HARD_PHI=("hipaa" "ehr" "healthcare")

--- a/tests/fixtures/security/verify-security.sh
+++ b/tests/fixtures/security/verify-security.sh
@@ -260,14 +260,13 @@ k_int=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/preview-forge" \
 # Spec-path 3-arg — must differ from integer + baseline.
 k_spec=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/preview-forge" \
   bash "$REPO_ROOT/scripts/preview-cache.sh" key "test" pro "$spec_file" 2>/dev/null)
-# Unknown 3-arg (non-integer, non-existent file) — documented behaviour
-# at preview-cache.sh:~110: emit a stderr warning and fall back to the
-# 4-field baseline key (no spec hash). Captured both streams so we can
-# assert the warning is present.
+# Unknown 3-arg (non-integer, non-existent file) — R-3 Phase 7 fail-fast:
+# exit 2 + stderr "does not exist", no stdout key. Previously warn+
+# fallback; ComBba independent verification proved the 4-field
+# collapse risk → reverted to CodeRabbit's original fail-fast recipe.
+k_unknown_rc=0
 k_unknown_combined=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/preview-forge" \
-  bash "$REPO_ROOT/scripts/preview-cache.sh" key "test" pro "not-an-existing-file" 2>&1)
-k_unknown=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/preview-forge" \
-  bash "$REPO_ROOT/scripts/preview-cache.sh" key "test" pro "not-an-existing-file" 2>/dev/null)
+  bash "$REPO_ROOT/scripts/preview-cache.sh" key "test" pro "not-an-existing-file" 2>&1) || k_unknown_rc=$?
 cd - >/dev/null
 # Repeat integer case in a clean dir without the ./26 trap for R6.
 tmp_clean=$(mktemp -d -t pf-t5-clean-XXXXXX); cd "$tmp_clean"
@@ -279,10 +278,10 @@ route_fails=0
 [[ "$k_none" =~ ^[0-9a-f]{16,}$ ]] || { fail "T-5 baseline (no 3rd arg) not hex"; route_fails=$((route_fails+1)); }
 [[ "$k_int" =~ ^[0-9a-f]{16,}$ && "$k_int" != "$k_none" ]] || { fail "T-5 integer branch: key same as baseline (override didn't fire)"; route_fails=$((route_fails+1)); }
 [[ "$k_spec" =~ ^[0-9a-f]{16,}$ && "$k_spec" != "$k_int" && "$k_spec" != "$k_none" ]] || { fail "T-5 spec-path branch: didn't produce distinct key"; route_fails=$((route_fails+1)); }
-[[ "$k_unknown" == "$k_none" ]] || { fail "T-5 unknown-token: did NOT fall back to baseline (spec_hash leaked?)"; route_fails=$((route_fails+1)); }
-[[ "$k_unknown_combined" == *"does not exist"* ]] || { fail "T-5 unknown-token: expected stderr warning, got '$k_unknown_combined'"; route_fails=$((route_fails+1)); }
+[[ "$k_unknown_rc" -eq 2 ]] || { fail "T-5 / R-3 unknown-token: expected exit 2, got rc=$k_unknown_rc"; route_fails=$((route_fails+1)); }
+[[ "$k_unknown_combined" == *"does not exist"* ]] || { fail "T-5 / R-3 unknown-token: expected stderr 'does not exist', got '$k_unknown_combined'"; route_fails=$((route_fails+1)); }
 [[ "$k_int" == "$k_int_clean" ]] || { fail "T-5 / R6: integer key changed when ./26 trap file existed"; route_fails=$((route_fails+1)); }
-[[ "$route_fails" -eq 0 ]] && pass "T-5 routing: baseline=$k_none integer=$k_int spec=$k_spec unknown=$k_unknown; R6 trap safe"
+[[ "$route_fails" -eq 0 ]] && pass "T-5 routing: baseline=$k_none integer=$k_int spec=$k_spec (unknown-token R-3 exit 2); R6 trap safe"
 rm -rf "$tmp_rt" "$tmp_clean"
 
 echo


### PR DESCRIPTION
Closes umbrella #33 (v1.7.0 Phase 7 — Refactoring & Code Quality). 5 items: 3 shipped here (R-1, R-3, R-4), R-2 already covered in #45 (T-9.4 atomic `cmd_put`), R-5 deferred per the umbrella's explicit "review only — decision whether to consolidate or keep independent" wording.

## Summary

| Item | File | Change | Effect |
|---|---|---|---|
| **R-1** | `scripts/preview-cache.sh` | Extract `py_sha256_file` / `py_file_age` / `py_read_json` helpers; refactor 9 inline `python3 -c` blocks down to 5 call sites + 4 helper defs | -36 LOC net · `encoding="utf-8"` centralized · uniform error handling |
| **R-2** | (already shipped in #45) | `cmd_put` atomic write via `mktemp` + `mv` | T-9.4 verified with 5-way concurrent SHA-match test |
| **R-3** | `scripts/preview-cache.sh` + `tests/fixtures/security/verify-security.sh` | `spec-missing` path: warn+fallback → **exit 2** | Closes the 4-field-key collapse surface ComBba independently verified (`d1ded960848eaa16`); v1.5.x legacy-entry poisoning path removed |
| **R-4** | `scripts/recommend-profile.sh:81` | JP/CN signal-bank TODO reclassified as product-scope deferred | Explains why (regulatory terminology needs native translators, not mechanical port) + when to revisit |
| **R-5** | — | Decision-only per umbrella | Keeping 26 advocates independent for now; revisit when the next advocate-wide block appears (consolidation delta stays small until then) |

## Review rounds before push

- **codex R1** — **CLEAN**. No P1/P2/P3. All four targeted check-points verified explicitly:
  1. `py_read_json` — 5/5 call sites use string literals, no user input interpolated
  2. R-3 back-compat — no executable repo caller passes a pre-creation `.json` spec path
  3. Empty-fallback semantics match pre-refactor `print('')` (newline → bash strips)
  4. T-5 fixture exercises the fail-fast path via `rc=$?` capture, safe under `set -e`
  Residual note only: `py_read_json` stays sharp-edged for future reuse because `expr` is source-interpolated. Current callers are controlled; future additions must stay literal.

- **Local smoke** — verify-plugin 56/0, verify-security 13 sections green (including the updated T-5/R-3 assertion), verify-rule9 3/3 green.

## Test plan

- [x] `bash -n scripts/preview-cache.sh` — syntax OK after refactor
- [x] `bash tests/fixtures/security/verify-security.sh` — 13/13 sections pass (T-5 now expects `rc=2 + stderr "does not exist"` for the unknown-token branch, replacing the prior warn+fallback expectation)
- [x] `bash tests/fixtures/rule9-fp-guard/verify-rule9.sh` — 3/3
- [x] `bash scripts/verify-plugin.sh` — 56/0
- [x] R-1 helper audit: `grep 'py_read_json "' scripts/preview-cache.sh` — 5 hits, all literal-expression callers
- [x] R-3 back-compat: grepped repo for `preview-cache.sh key.*\.json` — all executable invocations are tests; the production flow (`commands/new.md` §4/§6 and `ideation-lead.md` §I_LEAD) creates `idea.spec.json` before calling the strong-key put
- [x] R-4: visible change in recommend-profile.sh:81 comment is the new explanatory block

## Related

- Umbrella: #33 (v1.7.0 Phase 7 — 5 items, 3 here + R-2 in #45 + R-5 deferred)
- Audit source: [ComBba P7 comment on #25](https://github.com/Two-Weeks-Team/PreviewForgeForClaudeCode/pull/25#issuecomment-4310449270)
- Prior phases: #39 (P4), #41 (P1), #42 (P2), #44 (P3 Part A), #45 (P3 Part B)

Two conventional commits: 1 `docs:` (R-4), 1 `refactor:` (R-1 + R-3 bundled because R-3 relies on R-1's `py_sha256_file` helper).