### PR TITLE
test(v1.7.0): Phase 3 Part C — T-2 / T-3 / T-8 + macOS CI (T-12) — closes umbrella #32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,17 @@ concurrency:
 
 jobs:
   verify-plugin:
-    name: Verify plugin structure
-    runs-on: ubuntu-latest
+    name: Verify plugin structure (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        # T-12 (v1.7 audit Phase 3 Part C): macOS catches BSD/GNU userland
+        # divergence (mktemp template position, sed -i, find -exec) that
+        # ubuntu-only CI missed in PR #45. Windows deferred — bash-on-windows
+        # would require WSL action + script rewrites; tracked as follow-up.
+        os: [ubuntu-latest, macos-14]
     steps:
       - uses: actions/checkout@v6
 
@@ -77,13 +85,16 @@ jobs:
           [[ "$DEFAULT" == "standard" ]] || { echo "FAIL: defaultProfile expected 'standard', got '$DEFAULT'"; exit 1; }
           echo "✓ settings.json defaultProfile = standard"
 
-      - name: Fixture suites (Phase 1 security + Phase 3 T-4/T-6/T-9.2, v1.7.0+)
+      - name: Fixture suites (Phase 1 security + Phase 3 T-2/T-3/T-4/T-6/T-8/T-9.2, v1.7.0+)
         run: |
           # jsonschema already installed a few steps up; the fixtures
           # now fail-closed on missing dependency so this must stay in
           # the same job that pip-installs it.
           bash tests/fixtures/security/verify-security.sh
           bash tests/fixtures/rule9-fp-guard/verify-rule9.sh
+          bash tests/fixtures/filled-ratio/verify-filled-ratio.sh
+          bash tests/fixtures/normalize-constraints/verify-normalize.sh
+          bash tests/fixtures/lesson07-regression/verify-lesson07.sh
 
   test-hooks:
     name: Test hooks (unit)

--- a/plugins/preview-forge/schemas/idea-spec.schema.json
+++ b/plugins/preview-forge/schemas/idea-spec.schema.json
@@ -50,13 +50,16 @@
     },
     "must_have_constraints": {
       "type": "array",
-      "description": "Hard constraints captured by I1 Batch C. Canonical `type` buckets: regulatory | budget | latency | team_size | platform | data_residency. Free-form strings (e.g. 'air-gapped deployment', 'mandated vendor X') are also accepted so the Batch C 'Other' path is never silently dropped. S-3 (v1.7.0+): array is capped at 20 entries with per-field maxLength so a poisoned idea.spec.json cannot blow up advocate prompt size / Rule 9 containment budget.",
+      "description": "Hard constraints captured by I1 Batch C. Canonical `type` buckets: regulatory | budget | latency | team_size | platform | data_residency | other. Free-form strings (e.g. 'air-gapped deployment', 'mandated vendor X') belong under `type: \"other\"` with the verbatim text in `value` — so the Batch C 'Other' path is never silently dropped. S-3 (v1.7.0+): array is capped at 20 entries with per-field maxLength so a poisoned idea.spec.json cannot blow up advocate prompt size / Rule 9 containment budget. T-3 (v1.7 audit): the canonical 7-bucket `type.enum` and the `scripts/normalize-constraints.py` reference normalizer keep the cache key stable across I1 implementations.",
       "maxItems": 20,
       "items": {
         "type": "object",
         "required": ["type", "value"],
         "properties": {
-          "type": { "type": "string", "minLength": 1, "maxLength": 50 },
+          "type": {
+            "type": "string",
+            "enum": ["regulatory", "budget", "latency", "team_size", "platform", "data_residency", "other"]
+          },
           "value": { "type": "string", "minLength": 1, "maxLength": 2000 }
         },
         "additionalProperties": false

--- a/scripts/compute-filled-ratio.py
+++ b/scripts/compute-filled-ratio.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Preview Forge — `_filled_ratio` reference calculator (Phase 3 T-2).
+
+Computes the deterministic `_filled_ratio` for an `idea.spec.json` per the
+rule defined in `plugins/preview-forge/schemas/idea-spec.schema.json`
+`_filled_ratio.description`. Used by `tests/fixtures/filled-ratio/` to
+keep the schema doc + advocate prompt math from drifting from a single
+reference implementation.
+
+Counting rule (denominator = 9 semantic slots):
+  1. `idea_summary` — always 1 (`minLength: 1` is required by schema).
+  2. 3 nested objects (`target_persona`, `primary_surface`, `jobs_to_be_done`)
+     — binary slot: 1 IFF at least one sub-field is non-null AND non-'unknown'.
+  3. 3 leaf strings (`killer_feature`, `monetization_model`, `success_metric`)
+     — 1 each IFF non-null AND non-'unknown' (case-insensitive).
+  4. 2 arrays (`must_have_constraints`, `non_goals`)
+     — 1 each IFF `length >= 1` (empty array = 'user did not answer',
+        NOT an affirmative 'no constraints').
+
+Boundary cases (cross-checked by `tests/fixtures/filled-ratio/cases.json`):
+- B-3 'Skip interview' (only required keys) → 1/9 ≈ 0.1111 (fallback tier).
+- B-1 fast path (4 required answered, all optionals skipped) → 5/9 ≈ 0.5556
+  (medium tier under A-4).
+- Full path (every Q answered) → 9/9 = 1.0000 (high tier).
+
+Usage:
+  python3 scripts/compute-filled-ratio.py <idea.spec.json>          # prints ratio
+  python3 scripts/compute-filled-ratio.py --verbose <idea.spec.json> # + per-slot trace
+
+Exit:
+  0 — ratio printed to stdout.
+  2 — JSON parse error or non-object payload (stderr explains).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+NESTED_FIELDS = ("target_persona", "primary_surface", "jobs_to_be_done")
+LEAF_STRING_FIELDS = ("killer_feature", "monetization_model", "success_metric")
+ARRAY_FIELDS = ("must_have_constraints", "non_goals")
+
+
+def is_filled_string(value) -> bool:
+    """Non-null, non-empty after strip, and not the literal 'unknown' (case-insensitive)."""
+    if not isinstance(value, str):
+        return False
+    stripped = value.strip()
+    if not stripped:
+        return False
+    return stripped.lower() != "unknown"
+
+
+def nested_object_filled(obj) -> bool:
+    """A nested object slot counts IFF at least one sub-field is meaningfully filled."""
+    if not isinstance(obj, dict):
+        return False
+    for v in obj.values():
+        if v is None:
+            continue
+        if isinstance(v, str):
+            if is_filled_string(v):
+                return True
+        elif isinstance(v, bool):
+            # `offline_capable` is bool|null. False is still 'user answered'.
+            return True
+        elif v not in (None, "", []):
+            return True
+    return False
+
+
+def array_filled(arr) -> bool:
+    return isinstance(arr, list) and len(arr) >= 1
+
+
+def compute(spec: dict) -> tuple[float, list[tuple[str, bool]]]:
+    slots: list[tuple[str, bool]] = []
+    slots.append(("idea_summary", is_filled_string(spec.get("idea_summary"))))
+    for k in NESTED_FIELDS:
+        slots.append((k, nested_object_filled(spec.get(k))))
+    for k in LEAF_STRING_FIELDS:
+        slots.append((k, is_filled_string(spec.get(k))))
+    for k in ARRAY_FIELDS:
+        slots.append((k, array_filled(spec.get(k))))
+
+    filled_count = sum(1 for _, f in slots if f)
+    return filled_count / 9.0, slots
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    ap.add_argument("path", help="Path to idea.spec.json")
+    ap.add_argument("-v", "--verbose", action="store_true", help="Print slot breakdown to stderr")
+    ap.add_argument("--decimals", type=int, default=4, help="Decimals in the printed ratio (default 4)")
+    args = ap.parse_args()
+
+    try:
+        with open(args.path, encoding="utf-8") as f:
+            spec = json.load(f)
+    except FileNotFoundError:
+        print(f"ERR: {args.path}: file not found", file=sys.stderr)
+        sys.exit(2)
+    except json.JSONDecodeError as e:
+        print(f"ERR: {args.path}: invalid JSON ({e})", file=sys.stderr)
+        sys.exit(2)
+
+    if not isinstance(spec, dict):
+        print(f"ERR: {args.path}: top-level value must be an object", file=sys.stderr)
+        sys.exit(2)
+
+    ratio, slots = compute(spec)
+
+    if args.verbose:
+        print(f"slots filled (denominator 9):", file=sys.stderr)
+        for k, f in slots:
+            mark = "✓" if f else "·"
+            print(f"  {mark} {k}", file=sys.stderr)
+        filled = sum(1 for _, f in slots if f)
+        print(f"  → {filled}/9 = {ratio:.{args.decimals}f}", file=sys.stderr)
+
+    print(f"{ratio:.{args.decimals}f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/normalize-constraints.py
+++ b/scripts/normalize-constraints.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Preview Forge — `must_have_constraints` normalizer (Phase 3 T-3).
+
+Maps user-facing AskUserQuestion option labels (and free-form Other input)
+to the canonical `{type, value}` shape consumed by `must_have_constraints[]`
+in `idea.spec.json`. The mapping rules originate in
+`plugins/preview-forge/agents/ideation/idea-clarifier.md` Batch C.
+
+Canonical type buckets (must match the schema `type.enum` after T-3 ships):
+  regulatory · budget · latency · team_size · platform · data_residency · other
+
+Mapping rule:
+  - Pattern: `<bucket-keyword> (<inline-value>)` → type=bucket, value=inline
+    Example: `regulatory (PII/HIPAA/SOC2)` → {type: "regulatory", value: "PII/HIPAA/SOC2"}
+  - Bare canonical labels → type=bucket, value="<not-specified>"
+    Example: `budget tier` → {type: "budget", value: "tier-not-specified"}
+  - Anything else → type="other", value=raw user input verbatim
+    Example: `air-gapped deployment` → {type: "other", value: "air-gapped deployment"}
+
+Used by:
+  - I1 LLM (idea-clarifier) for deterministic serialization across runs
+    (ensures cache key stability via consistent JSON output).
+  - `tests/fixtures/normalize-constraints/` for CI regression on the rule.
+
+Usage:
+  python3 scripts/normalize-constraints.py "<label>" ["<inline_value>"]
+    → prints `{"type": "...", "value": "..."}` JSON to stdout.
+  python3 scripts/normalize-constraints.py --batch < labels.txt
+    → reads one label per stdin line, prints one normalized JSON object per line.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+CANONICAL_TYPES = (
+    "regulatory",
+    "budget",
+    "latency",
+    "team_size",
+    "platform",
+    "data_residency",
+    "other",
+)
+
+# Pattern: <bucket-keyword>[<whitespace>][(<inline-value>)]
+# Bucket keywords map: user-facing label → canonical type.
+LABEL_TO_TYPE = {
+    "regulatory": "regulatory",
+    "budget tier": "budget",
+    "budget": "budget",
+    "latency sla": "latency",
+    "latency": "latency",
+    "team size": "team_size",
+    "team_size": "team_size",
+    "data residency": "data_residency",
+    "data_residency": "data_residency",
+    "platform lock-in": "platform",
+    "platform": "platform",
+}
+
+# Default value for bare canonical labels (no parenthetical).
+DEFAULT_VALUE = {
+    "regulatory": "not-specified",
+    "budget": "tier-not-specified",
+    "latency": "SLA-not-specified",
+    "team_size": "not-specified",
+    "platform": "not-specified",
+    "data_residency": "not-specified",
+}
+
+
+def normalize(label: str, inline_value: str | None = None) -> dict:
+    """Normalize a single user-facing label → {type, value} dict."""
+    if not isinstance(label, str):
+        return {"type": "other", "value": str(label)}
+    raw = label.strip()
+    if not raw:
+        return {"type": "other", "value": ""}
+
+    # Extract `keyword (inline)` form via regex first.
+    m = re.match(r"^\s*([^()]+?)\s*\(\s*(.+?)\s*\)\s*$", raw)
+    if m:
+        keyword = m.group(1).strip().lower()
+        inline = m.group(2).strip()
+        canonical = LABEL_TO_TYPE.get(keyword)
+        if canonical:
+            return {"type": canonical, "value": inline_value or inline}
+        # Not a canonical bucket — fall through to "other" with full raw text.
+
+    # Bare canonical label (no parens).
+    keyword_lower = raw.lower()
+    canonical = LABEL_TO_TYPE.get(keyword_lower)
+    if canonical:
+        return {
+            "type": canonical,
+            "value": inline_value or DEFAULT_VALUE.get(canonical, "not-specified"),
+        }
+
+    # Free-form / Other.
+    return {"type": "other", "value": inline_value or raw}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    ap.add_argument("label", nargs="?", help="User-facing constraint label")
+    ap.add_argument(
+        "inline_value",
+        nargs="?",
+        default=None,
+        help="Optional override for the value field (overrides parenthetical extraction)",
+    )
+    ap.add_argument("--batch", action="store_true", help="Read labels from stdin (one per line)")
+    args = ap.parse_args()
+
+    if args.batch:
+        for line in sys.stdin:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            print(json.dumps(normalize(line), ensure_ascii=False))
+        return
+
+    if args.label is None:
+        ap.error("label argument is required when --batch is not used")
+
+    print(json.dumps(normalize(args.label, args.inline_value), ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/ASSESSMENT.md
+++ b/tests/fixtures/ASSESSMENT.md
@@ -1,0 +1,89 @@
+# Phase 3 Part C — T-7 / T-12 Assessment
+
+> Two umbrella #32 items were marked "(assessment)" rather than direct ship.
+> This document captures the cost/benefit and the decision so the umbrella can
+> be closed without leaving an open question.
+
+## T-7 — Stage 2 mock UX harness (AskUserQuestion replay)
+
+**Goal**: Run a deterministic e2e simulation of a `/pf:new` session by
+recording then replaying AskUserQuestion responses (Socratic interview
++ Gate H1 pick + Gate H2 ship), so CI can catch regressions in the
+multi-modal user flow without a real Claude Code session.
+
+**Cost**:
+- AskUserQuestion is a Claude Code *tool call*. The Claude side is part
+  of the model's runtime, not a library we can import. Stubbing means
+  running an alternate harness that intercepts the tool-call event,
+  feeds canned responses, and routes the resumed run forward. This
+  harness has no upstream reference and would have to live entirely in
+  this repo as a test-only scaffold.
+- The agents' system prompts are written assuming live Claude inference
+  (e.g. I_LEAD's "single message N Task tool calls"). A mock harness
+  cannot reproduce that — at best it can record a *known-good* trace
+  and replay artifact-level checkpoints (idea.spec.json → previews.json
+  → chosen_preview.json) and assert each is byte-stable.
+- Estimated build cost: 1–2 days of focused work. Maintenance risk
+  rises sharply because every new agent prompt change can desync the
+  recorded trace.
+
+**Benefit**:
+- Would catch bugs like "Socratic interview drops Batch C silently" or
+  "weak-replay sidecar not written on cache hit" earlier than user
+  e2e runs (currently the only signal).
+- Would unlock LESSON 0.7-style narrative regression tests (we already
+  cover the *artifact-level* contract via T-8 / Rule 9 fixture, so the
+  marginal value of replaying the modal sequence on top is moderate
+  but not critical).
+
+**Decision: defer to post-hackathon**.
+
+Rationale:
+1. The artifact-level fixtures (`tests/fixtures/security/`, `rule9-fp-guard/`,
+   `filled-ratio/`, `normalize-constraints/`, `lesson07-regression/`) cover
+   the byte-stable contracts that actually break at runtime.
+2. The mock harness's main payoff — catching regressions in user-modal
+   flow — is outweighed by maintenance overhead for a one-week hackathon
+   where every agent prompt is still iterating.
+3. A new GitHub issue will track this for the post-hackathon roadmap so
+   the assessment isn't lost.
+
+**Re-open trigger**: if a Socratic-interview regression slips past the
+artifact fixtures and reaches a real run (LESSON 0.7-style failure in
+the modal flow itself), revisit T-7 immediately.
+
+## T-12 — Cross-platform CI matrix (Ubuntu / macOS / Windows)
+
+**Goal**: Ensure all bash-based fixtures and `scripts/*.sh` work on the
+three platforms a real Claude Code user might be on.
+
+**Cost**:
+- **Ubuntu**: already covered. No work.
+- **macOS**: low. Adds one matrix dimension to existing CI jobs. Catches
+  BSD-vs-GNU userland differences (`mktemp` template position, `sed -i`
+  syntax, `date` flags) — we have already hit one of these in the v1.7
+  audit (PR #45's `mktemp` X-at-end fix). Worth it.
+- **Windows**: high. Bash is not native; would require WSL or
+  bash-on-windows action. Most plugin scripts use Unix-only tooling
+  (`shasum`, `find -exec`, `mktemp`). Reworking everything to
+  cross-platform is a separate workstream.
+
+**Benefit**:
+- macOS coverage is the highest-leverage addition: most Claude Code
+  users in the hackathon target market are on macOS, and all the
+  development-time runs of this plugin happen there. The PR #45 mktemp
+  surprise wouldn't have been caught by Ubuntu-only CI.
+- Windows coverage is desirable for completeness but not gating for
+  hackathon judging (judges run Mac or Linux).
+
+**Decision: ship macOS now, defer Windows**.
+
+This commit adds a `runs-on` matrix `[ubuntu-latest, macos-14]` to the
+fixture-suite job in `.github/workflows/ci.yml` so every fixture suite
+runs on both. Windows tracked as a follow-up issue.
+
+## Tracking
+
+- T-7 e2e mock harness → opened as a separate post-hackathon issue (not
+  in this PR) before umbrella #32 closes.
+- T-12 macOS CI → shipped in this PR. Windows tracked likewise.

--- a/tests/fixtures/filled-ratio/cases.json
+++ b/tests/fixtures/filled-ratio/cases.json
@@ -1,0 +1,152 @@
+[
+  {
+    "id": "skip-interview",
+    "rationale": "B-3 Skip-interview path — only the 3 schema-required keys. Should land in fallback tier (< 0.2).",
+    "expected_ratio": 0.1111,
+    "spec": {
+      "_schema_version": "1.0.0",
+      "_filled_ratio": 0.0,
+      "idea_summary": "회의록 자동 정리 + action item 추출"
+    }
+  },
+  {
+    "id": "fast-path-4-required",
+    "rationale": "B-1 fast path — 4 required answered, all optionals skipped. idea_summary + target_persona.profile + primary_surface.platform + killer_feature + must_have_constraints[1] = 5 slots. Lands in medium tier (0.4–0.7).",
+    "expected_ratio": 0.5556,
+    "spec": {
+      "_schema_version": "1.0.0",
+      "_filled_ratio": 0.5556,
+      "idea_summary": "회의록 자동 정리 + action item 추출",
+      "target_persona": {
+        "profile": "스타트업 PM",
+        "primary_pain": null,
+        "usage_frequency": null
+      },
+      "primary_surface": {
+        "platform": "web",
+        "sync_model": null,
+        "offline_capable": null
+      },
+      "jobs_to_be_done": {
+        "functional": null,
+        "emotional": null,
+        "social": null
+      },
+      "killer_feature": "회의 직후 자동 action item 분배",
+      "must_have_constraints": [{"type": "regulatory", "value": "PII"}],
+      "non_goals": [],
+      "monetization_model": null,
+      "success_metric": null
+    }
+  },
+  {
+    "id": "full-path-9-9",
+    "rationale": "Every semantic slot answered. High tier ground truth.",
+    "expected_ratio": 1.0,
+    "spec": {
+      "_schema_version": "1.0.0",
+      "_filled_ratio": 1.0,
+      "idea_summary": "회의록 자동 정리 + action item 추출",
+      "target_persona": {
+        "profile": "스타트업 PM",
+        "primary_pain": "회의 직후 30분 정리 시간 낭비",
+        "usage_frequency": "daily"
+      },
+      "primary_surface": {
+        "platform": "web",
+        "sync_model": "real-time",
+        "offline_capable": false
+      },
+      "jobs_to_be_done": {
+        "functional": "회의 후 5분 안에 action item 자동 분배",
+        "emotional": "안심",
+        "social": "팀에 정확한 follow-up 보여주기"
+      },
+      "killer_feature": "회의 직후 자동 action item 분배",
+      "must_have_constraints": [{"type": "regulatory", "value": "PII"}],
+      "non_goals": ["video editing", "billing"],
+      "monetization_model": "subscription",
+      "success_metric": "weekly active teams"
+    }
+  },
+  {
+    "id": "edge-nested-all-null",
+    "rationale": "Nested object present but all sub-fields null → should NOT count as filled (binary slot rule). Counted slots: idea_summary only.",
+    "expected_ratio": 0.1111,
+    "spec": {
+      "_schema_version": "1.0.0",
+      "_filled_ratio": 0.1111,
+      "idea_summary": "회의록 자동 정리 + action item 추출",
+      "target_persona": {
+        "profile": null,
+        "primary_pain": null,
+        "usage_frequency": null
+      },
+      "primary_surface": {
+        "platform": null,
+        "sync_model": null,
+        "offline_capable": null
+      },
+      "jobs_to_be_done": {
+        "functional": null,
+        "emotional": null,
+        "social": null
+      },
+      "killer_feature": null,
+      "must_have_constraints": [],
+      "non_goals": [],
+      "monetization_model": null,
+      "success_metric": null
+    }
+  },
+  {
+    "id": "edge-leaf-unknown",
+    "rationale": "Leaf string set to 'unknown' (case-insensitive) does NOT count as filled. Slots: idea_summary + target_persona (profile non-null) = 2/9 ≈ 0.2222.",
+    "expected_ratio": 0.2222,
+    "spec": {
+      "_schema_version": "1.0.0",
+      "_filled_ratio": 0.2222,
+      "idea_summary": "회의록 자동 정리 + action item 추출",
+      "target_persona": {
+        "profile": "스타트업 PM",
+        "primary_pain": null,
+        "usage_frequency": null
+      },
+      "killer_feature": "Unknown",
+      "monetization_model": "unknown",
+      "success_metric": "UNKNOWN",
+      "must_have_constraints": [],
+      "non_goals": []
+    }
+  },
+  {
+    "id": "edge-empty-arrays",
+    "rationale": "Empty arrays do NOT count as filled (length >= 1 required). Slots: idea_summary + target_persona + primary_surface + killer_feature = 4/9 ≈ 0.4444.",
+    "expected_ratio": 0.4444,
+    "spec": {
+      "_schema_version": "1.0.0",
+      "_filled_ratio": 0.4444,
+      "idea_summary": "회의록 자동 정리 + action item 추출",
+      "target_persona": {"profile": "스타트업 PM"},
+      "primary_surface": {"platform": "web"},
+      "killer_feature": "auto action item",
+      "must_have_constraints": [],
+      "non_goals": []
+    }
+  },
+  {
+    "id": "edge-bool-false",
+    "rationale": "primary_surface.offline_capable=false IS 'user answered' (not null), so primary_surface counts. Slots: idea_summary + primary_surface = 2/9 ≈ 0.2222.",
+    "expected_ratio": 0.2222,
+    "spec": {
+      "_schema_version": "1.0.0",
+      "_filled_ratio": 0.2222,
+      "idea_summary": "회의록 자동 정리 + action item 추출",
+      "primary_surface": {
+        "platform": null,
+        "sync_model": null,
+        "offline_capable": false
+      }
+    }
+  }
+]

--- a/tests/fixtures/filled-ratio/verify-filled-ratio.sh
+++ b/tests/fixtures/filled-ratio/verify-filled-ratio.sh
@@ -7,7 +7,7 @@
 #
 # Exit 0 = all cases match. Exit 1 = at least one mismatch (CI-blocking).
 
-set -u
+set -euo pipefail
 
 FIXTURES_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$FIXTURES_DIR/../../.." && pwd)"

--- a/tests/fixtures/filled-ratio/verify-filled-ratio.sh
+++ b/tests/fixtures/filled-ratio/verify-filled-ratio.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# T-2 — `_filled_ratio` reference verifier.
+#
+# For each case in cases.json, write the embedded `spec` object to a temp
+# file, run scripts/compute-filled-ratio.py, and assert the printed ratio
+# matches `expected_ratio` to 4 decimal places.
+#
+# Exit 0 = all cases match. Exit 1 = at least one mismatch (CI-blocking).
+
+set -u
+
+FIXTURES_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$FIXTURES_DIR/../../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/compute-filled-ratio.py"
+
+if [[ ! -x "$SCRIPT" && ! -r "$SCRIPT" ]]; then
+  echo "x compute-filled-ratio.py not found at $SCRIPT" >&2
+  exit 1
+fi
+
+echo "=== T-2 _filled_ratio verify ==="
+echo
+
+python3 -c "import json; json.load(open('$FIXTURES_DIR/cases.json'))" >/dev/null \
+  || { echo "x cases.json malformed" >&2; exit 1; }
+
+case_count=$(python3 -c "import json; print(len(json.load(open('$FIXTURES_DIR/cases.json'))))")
+
+fails=0
+for i in $(seq 0 $((case_count - 1))); do
+  meta=$(python3 - "$FIXTURES_DIR/cases.json" "$i" <<'PY'
+import json, sys, tempfile, os
+cases = json.load(open(sys.argv[1]))
+case = cases[int(sys.argv[2])]
+fd, path = tempfile.mkstemp(suffix=".idea.spec.json", prefix="pf-fr-")
+with os.fdopen(fd, "w", encoding="utf-8") as f:
+    json.dump(case["spec"], f, ensure_ascii=False)
+print(case["id"])
+print(case["expected_ratio"])
+print(path)
+PY
+)
+  cid=$(echo "$meta" | sed -n '1p')
+  expected=$(echo "$meta" | sed -n '2p')
+  spec_path=$(echo "$meta" | sed -n '3p')
+
+  actual=$(python3 "$SCRIPT" "$spec_path" 2>/dev/null) || {
+    echo "  FAIL [$cid] script exit non-zero"
+    fails=$((fails + 1))
+    rm -f "$spec_path"
+    continue
+  }
+
+  # 4-decimal compare via python (avoids bash float lib).
+  match=$(python3 -c "
+import sys
+expected = float(sys.argv[1])
+actual = float(sys.argv[2])
+print('1' if abs(expected - actual) < 0.0001 else '0')
+" "$expected" "$actual")
+
+  if [[ "$match" == "1" ]]; then
+    echo "  OK   [$cid] ratio=$actual (expected $expected)"
+  else
+    echo "  FAIL [$cid] ratio=$actual (expected $expected)"
+    fails=$((fails + 1))
+  fi
+  rm -f "$spec_path"
+done
+
+echo
+if [[ $fails -eq 0 ]]; then
+  echo "OK T-2 _filled_ratio reference — all $case_count cases match schema rule."
+  exit 0
+fi
+echo "x T-2 _filled_ratio reference — $fails of $case_count cases mismatched."
+exit 1

--- a/tests/fixtures/filled-ratio/verify-filled-ratio.sh
+++ b/tests/fixtures/filled-ratio/verify-filled-ratio.sh
@@ -21,10 +21,10 @@ fi
 echo "=== T-2 _filled_ratio verify ==="
 echo
 
-python3 -c "import json; json.load(open('$FIXTURES_DIR/cases.json'))" >/dev/null \
+python3 -c "import json, sys; json.load(open(sys.argv[1]))" "$FIXTURES_DIR/cases.json" >/dev/null \
   || { echo "x cases.json malformed" >&2; exit 1; }
 
-case_count=$(python3 -c "import json; print(len(json.load(open('$FIXTURES_DIR/cases.json'))))")
+case_count=$(python3 -c "import json, sys; print(len(json.load(open(sys.argv[1]))))" "$FIXTURES_DIR/cases.json")
 
 fails=0
 for i in $(seq 0 $((case_count - 1))); do

--- a/tests/fixtures/lesson07-regression/README.md
+++ b/tests/fixtures/lesson07-regression/README.md
@@ -1,0 +1,41 @@
+# LESSON 0.7 Regression Fixture (T-8)
+
+> Validates that the Rule 9 idea-drift detector anchors on **chosen_preview**
+> (the user's Gate H1 pick) — not on the panel composite winner — even when
+> the two diverge.
+
+## Why this fixture exists
+
+[LESSON 0.7](../../../plugins/preview-forge/memory/LESSONS.md) records the
+real failure: in `r-20260422-184337` the panel composite #1 was P02
+(Slack bot), but the user actually picked P10 (TP-favored API-first). The
+plugin must keep the SpecDD/Engineering vocabulary aligned with **P10**.
+A regression here would silently push the project back toward the panel's
+preferred direction.
+
+This fixture cannot use the same rule9-fp-guard cases because those pair
+chosen_preview with vocabulary that already matches it. Here the test is:
+
+- An incoming Write that uses **chosen_preview vocabulary** must pass
+  (exit 0), even though the composite_winner has different vocabulary.
+- An incoming Write that uses **composite_winner vocabulary** must be
+  blocked (exit 2), because the user opted out of that direction at H1.
+
+## Cases
+
+| ID | chosen_preview pick | composite_winner | Incoming Write | Expected |
+|---|---|---|---|---|
+| `respect-user-pick-api-first` | P10 (API-first) | P02 (Slack bot) | OpenAPI spec for P10 | exit 0 |
+| `block-drift-to-composite-winner` | P10 (API-first) | P02 (Slack bot) | Slack-bot README | exit 2 |
+
+## Run
+
+```bash
+bash tests/fixtures/lesson07-regression/verify-lesson07.sh
+```
+
+## Layer-0 cross-ref
+
+- Rule 9 (idea fidelity) — `methodology/global.md`
+- `plugins/preview-forge/hooks/idea-drift-detector.py` — implementation
+- `plugins/preview-forge/memory/LESSONS.md` LESSON 0.7 — narrative

--- a/tests/fixtures/lesson07-regression/cases.json
+++ b/tests/fixtures/lesson07-regression/cases.json
@@ -1,0 +1,76 @@
+[
+  {
+    "id": "respect-user-pick-api-first",
+    "class": "technical",
+    "target_subpath": "specs/openapi.yaml",
+    "rationale": "User picked P10 API-first. Composite winner was P02 Slack bot (different vocabulary). Incoming OpenAPI write uses P10 vocabulary — should pass Rule 9 because the anchor is chosen_preview, not composite_winner.",
+    "chosen_preview": {
+      "id": "P10",
+      "idea_summary": "Invoice reconciliation API for freelance accountants",
+      "title": "Reconciliation API",
+      "pitch": "Automate invoice reconciliation across multiple banking providers with audit-ready diffs",
+      "one_liner": "Invoice reconciliation API for freelance accountants"
+    },
+    "panel_composite_winner_label": "P02-the-ops-veteran (Slack bot)",
+    "idea_spec": {
+      "_schema_version": "1.0.0",
+      "_filled_ratio": 0.8,
+      "idea_summary": "Invoice reconciliation API for freelance accountants",
+      "target_persona": {
+        "profile": "freelance accountant",
+        "primary_pain": "deadline-panic during tax season",
+        "usage_frequency": "daily"
+      },
+      "primary_surface": {"platform": "api", "sync_model": "real-time"},
+      "jobs_to_be_done": {
+        "functional": "reconcile invoices across bank feeds in under 5 minutes",
+        "emotional": "feel in control, not panicked",
+        "social": "look meticulous to clients"
+      },
+      "must_have_constraints": [
+        {"type": "regulatory", "value": "SOC2 audit-ready logging"},
+        {"type": "latency", "value": "<500ms p95 reconciliation endpoint"}
+      ],
+      "non_goals": ["general accounting UI", "tax filing"]
+    },
+    "incoming_content": "openapi: 3.1.0\ninfo:\n  title: Invoice Reconciliation API\n  version: 1.0.0\n  description: Reconciliation endpoints for freelance accountant clients with SOC2 audit logging — bank feed reconciliation under 500ms p95.\npaths:\n  /reconcile/invoices:\n    post:\n      summary: Reconcile a batch of invoices against bank feeds\n      description: Accepts invoice records and matches them against connected bank feed transactions. Returns audit-ready diffs.\n      responses:\n        '200':\n          description: Reconciliation result with audit diffs\n  /reconcile/status:\n    get:\n      summary: Poll reconciliation job status\ncomponents:\n  schemas:\n    Invoice:\n      type: object\n      required: [id, amount, currency, vendor]\n      properties:\n        id: {type: string}\n        amount: {type: number}\n        currency: {type: string}\n        vendor: {type: string}\n",
+    "expected_exit": 0
+  },
+  {
+    "id": "block-drift-to-composite-winner",
+    "class": "narrative",
+    "target_subpath": "apps/web/README.md",
+    "rationale": "User picked P10 API-first. If a write drifts toward the panel composite_winner P02 Slack bot (totally different vocabulary — Slack, channel, slash command, slackbot), Rule 9 must block. This is the exact LESSON 0.7 regression — the system silently pulling toward the panel's preferred direction.",
+    "chosen_preview": {
+      "id": "P10",
+      "idea_summary": "Invoice reconciliation API for freelance accountants",
+      "title": "Reconciliation API",
+      "pitch": "Automate invoice reconciliation across multiple banking providers with audit-ready diffs",
+      "one_liner": "Invoice reconciliation API for freelance accountants"
+    },
+    "panel_composite_winner_label": "P02-the-ops-veteran (Slack bot)",
+    "idea_spec": {
+      "_schema_version": "1.0.0",
+      "_filled_ratio": 0.8,
+      "idea_summary": "Invoice reconciliation API for freelance accountants",
+      "target_persona": {
+        "profile": "freelance accountant",
+        "primary_pain": "deadline-panic during tax season",
+        "usage_frequency": "daily"
+      },
+      "primary_surface": {"platform": "api", "sync_model": "real-time"},
+      "jobs_to_be_done": {
+        "functional": "reconcile invoices across bank feeds in under 5 minutes",
+        "emotional": "feel in control, not panicked",
+        "social": "look meticulous to clients"
+      },
+      "must_have_constraints": [
+        {"type": "regulatory", "value": "SOC2 audit-ready logging"},
+        {"type": "latency", "value": "<500ms p95 reconciliation endpoint"}
+      ],
+      "non_goals": ["general accounting UI", "tax filing"]
+    },
+    "incoming_content": "# Slack Standup Bot\n\nA conversational Slack bot that runs daily standups in any channel. Members reply with their updates via slash command and the bot summarizes participation.\n\n## Slash commands\n\n- `/standup start` — open today's standup thread in the current channel\n- `/standup remind` — DM members who haven't replied yet\n- `/standup summary` — post the rolled-up text summary back to the channel\n\n## Setup\n\n```bash\nnpm install\nSLACK_TOKEN=xoxb-... SLACK_SIGNING=... npm run dev\n```\n\nAdd the bot to a channel, then anyone can invoke `/standup` to start a session.\n\n## Notes\n\nOnly works in Slack. Channel members must opt in via the slash command before the bot can DM them. Workspace admins can disable the bot per-channel from the Slack admin console.\n",
+    "expected_exit": 2
+  }
+]

--- a/tests/fixtures/lesson07-regression/verify-lesson07.sh
+++ b/tests/fixtures/lesson07-regression/verify-lesson07.sh
@@ -22,10 +22,10 @@ PLUGIN_ROOT="$REPO_ROOT/plugins/preview-forge"
 echo "=== T-8 LESSON 0.7 regression verify ==="
 echo
 
-python3 -c "import json; json.load(open('$FIXTURES_DIR/cases.json'))" >/dev/null \
+python3 -c "import json, sys; json.load(open(sys.argv[1]))" "$FIXTURES_DIR/cases.json" >/dev/null \
   || { echo "x cases.json malformed" >&2; exit 1; }
 
-case_count=$(python3 -c "import json; print(len(json.load(open('$FIXTURES_DIR/cases.json'))))")
+case_count=$(python3 -c "import json, sys; print(len(json.load(open(sys.argv[1]))))" "$FIXTURES_DIR/cases.json")
 
 fails=0
 for i in $(seq 0 $((case_count - 1))); do

--- a/tests/fixtures/lesson07-regression/verify-lesson07.sh
+++ b/tests/fixtures/lesson07-regression/verify-lesson07.sh
@@ -10,7 +10,7 @@
 # not on the panel composite_winner — the regression LESSON 0.7
 # warns about.
 
-set -u
+set -euo pipefail
 
 FIXTURES_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$FIXTURES_DIR/../../.." && pwd)"

--- a/tests/fixtures/lesson07-regression/verify-lesson07.sh
+++ b/tests/fixtures/lesson07-regression/verify-lesson07.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# T-8 — LESSON 0.7 regression verifier.
+#
+# For each case in cases.json, materialise the run workspace
+# (chosen_preview.json + idea.spec.json) and pipe an Edit/Write hook
+# input describing the incoming content. Assert the observed exit code
+# matches expected_exit.
+#
+# Goal: prove that Rule 9 anchors on chosen_preview (user's H1 pick),
+# not on the panel composite_winner — the regression LESSON 0.7
+# warns about.
+
+set -u
+
+FIXTURES_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$FIXTURES_DIR/../../.." && pwd)"
+HOOK="$REPO_ROOT/plugins/preview-forge/hooks/idea-drift-detector.py"
+PLUGIN_ROOT="$REPO_ROOT/plugins/preview-forge"
+
+[[ -x "$HOOK" || -r "$HOOK" ]] || { echo "x idea-drift-detector.py missing at $HOOK" >&2; exit 1; }
+
+echo "=== T-8 LESSON 0.7 regression verify ==="
+echo
+
+python3 -c "import json; json.load(open('$FIXTURES_DIR/cases.json'))" >/dev/null \
+  || { echo "x cases.json malformed" >&2; exit 1; }
+
+case_count=$(python3 -c "import json; print(len(json.load(open('$FIXTURES_DIR/cases.json'))))")
+
+fails=0
+for i in $(seq 0 $((case_count - 1))); do
+  tmp="$(mktemp -d -t pf-l07-XXXXXX)"
+  meta=$(python3 - "$FIXTURES_DIR/cases.json" "$i" "$tmp" <<'PY'
+import json, pathlib, sys
+cases = json.load(open(sys.argv[1]))
+case = cases[int(sys.argv[2])]
+tmp = pathlib.Path(sys.argv[3])
+run_dir = tmp / "runs" / "r-fixture"
+target = run_dir / case["target_subpath"]
+target.parent.mkdir(parents=True, exist_ok=True)
+(run_dir / "chosen_preview.json").write_text(
+    json.dumps(case["chosen_preview"]), encoding="utf-8"
+)
+(run_dir / "idea.spec.json").write_text(
+    json.dumps(case["idea_spec"]), encoding="utf-8"
+)
+print(case["id"])
+print(case.get("class", "?"))
+print(case["expected_exit"])
+print(target.resolve())
+PY
+)
+  cid=$(echo "$meta" | sed -n '1p')
+  cclass=$(echo "$meta" | sed -n '2p')
+  expected=$(echo "$meta" | sed -n '3p')
+  abs_target=$(echo "$meta" | sed -n '4p')
+
+  # Build hook input: PreToolUse Edit on the target with incoming_content.
+  hook_input=$(python3 - "$FIXTURES_DIR/cases.json" "$i" "$abs_target" <<'PY'
+import json, sys
+cases = json.load(open(sys.argv[1]))
+case = cases[int(sys.argv[2])]
+target = sys.argv[3]
+print(json.dumps({
+    "tool_name": "Write",
+    "tool_input": {
+        "file_path": target,
+        "content": case["incoming_content"]
+    }
+}))
+PY
+)
+
+  set +e
+  echo "$hook_input" | CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" python3 "$HOOK" >/dev/null 2>&1
+  actual=$?
+  set -e
+
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  OK   [$cid] [$cclass] exit=$actual (expected)"
+  else
+    echo "  FAIL [$cid] [$cclass] exit=$actual (expected $expected)"
+    fails=$((fails + 1))
+  fi
+  rm -rf "$tmp"
+done
+
+echo
+if [[ $fails -eq 0 ]]; then
+  echo "OK T-8 LESSON 0.7 regression — Rule 9 anchors on chosen_preview, not composite_winner."
+  exit 0
+fi
+echo "x T-8 LESSON 0.7 regression — $fails of $case_count cases mismatched."
+exit 1

--- a/tests/fixtures/normalize-constraints/cases.json
+++ b/tests/fixtures/normalize-constraints/cases.json
@@ -1,0 +1,67 @@
+[
+  {
+    "id": "regulatory-with-inline",
+    "input": "regulatory (PII/HIPAA/SOC2)",
+    "expected": {"type": "regulatory", "value": "PII/HIPAA/SOC2"}
+  },
+  {
+    "id": "budget-tier-bare",
+    "input": "budget tier",
+    "expected": {"type": "budget", "value": "tier-not-specified"}
+  },
+  {
+    "id": "latency-sla-bare",
+    "input": "latency SLA",
+    "expected": {"type": "latency", "value": "SLA-not-specified"}
+  },
+  {
+    "id": "latency-with-inline",
+    "input": "latency (<500ms p95)",
+    "expected": {"type": "latency", "value": "<500ms p95"}
+  },
+  {
+    "id": "team-size-bare",
+    "input": "team size",
+    "expected": {"type": "team_size", "value": "not-specified"}
+  },
+  {
+    "id": "data-residency-bare",
+    "input": "data residency",
+    "expected": {"type": "data_residency", "value": "not-specified"}
+  },
+  {
+    "id": "platform-lockin",
+    "input": "platform lock-in (AWS)",
+    "expected": {"type": "platform", "value": "AWS"}
+  },
+  {
+    "id": "freeform-other",
+    "input": "air-gapped deployment",
+    "expected": {"type": "other", "value": "air-gapped deployment"}
+  },
+  {
+    "id": "freeform-korean",
+    "input": "벤더 X 사용 강제",
+    "expected": {"type": "other", "value": "벤더 X 사용 강제"}
+  },
+  {
+    "id": "edge-empty",
+    "input": "",
+    "expected": {"type": "other", "value": ""}
+  },
+  {
+    "id": "edge-whitespace-only",
+    "input": "   ",
+    "expected": {"type": "other", "value": ""}
+  },
+  {
+    "id": "edge-mismatched-parens",
+    "input": "regulatory (PII",
+    "expected": {"type": "other", "value": "regulatory (PII"}
+  },
+  {
+    "id": "edge-canonical-uppercase",
+    "input": "REGULATORY",
+    "expected": {"type": "regulatory", "value": "not-specified"}
+  }
+]

--- a/tests/fixtures/normalize-constraints/verify-normalize.sh
+++ b/tests/fixtures/normalize-constraints/verify-normalize.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# T-3 — must_have_constraints normalizer verifier.
+#
+# For each case in cases.json, run scripts/normalize-constraints.py with
+# the input label and assert the output JSON matches expected.
+
+set -u
+
+FIXTURES_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$FIXTURES_DIR/../../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/normalize-constraints.py"
+
+[[ -r "$SCRIPT" ]] || { echo "x normalize-constraints.py missing at $SCRIPT" >&2; exit 1; }
+
+echo "=== T-3 must_have_constraints normalize verify ==="
+echo
+
+python3 -c "import json; json.load(open('$FIXTURES_DIR/cases.json'))" >/dev/null \
+  || { echo "x cases.json malformed" >&2; exit 1; }
+
+case_count=$(python3 -c "import json; print(len(json.load(open('$FIXTURES_DIR/cases.json'))))")
+
+fails=0
+for i in $(seq 0 $((case_count - 1))); do
+  meta=$(python3 - "$FIXTURES_DIR/cases.json" "$i" <<'PY'
+import json, sys
+cases = json.load(open(sys.argv[1]))
+case = cases[int(sys.argv[2])]
+print(case["id"])
+print(case["input"])
+print(json.dumps(case["expected"], ensure_ascii=False, sort_keys=True))
+PY
+)
+  cid=$(echo "$meta" | sed -n '1p')
+  input=$(echo "$meta" | sed -n '2p')
+  expected=$(echo "$meta" | sed -n '3p')
+
+  actual_raw=$(python3 "$SCRIPT" "$input" 2>/dev/null) || {
+    echo "  FAIL [$cid] script exit non-zero (input='$input')"
+    fails=$((fails + 1))
+    continue
+  }
+
+  # Sort keys for deterministic compare
+  actual=$(python3 -c "import json,sys; print(json.dumps(json.loads(sys.argv[1]), ensure_ascii=False, sort_keys=True))" "$actual_raw")
+
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  OK   [$cid] '$input' → $actual"
+  else
+    echo "  FAIL [$cid] '$input'"
+    echo "         expected: $expected"
+    echo "         actual:   $actual"
+    fails=$((fails + 1))
+  fi
+done
+
+echo
+if [[ $fails -eq 0 ]]; then
+  echo "OK T-3 normalize-constraints — all $case_count cases match canonical mapping."
+  exit 0
+fi
+echo "x T-3 normalize-constraints — $fails of $case_count cases mismatched."
+exit 1

--- a/tests/fixtures/normalize-constraints/verify-normalize.sh
+++ b/tests/fixtures/normalize-constraints/verify-normalize.sh
@@ -4,7 +4,7 @@
 # For each case in cases.json, run scripts/normalize-constraints.py with
 # the input label and assert the output JSON matches expected.
 
-set -u
+set -euo pipefail
 
 FIXTURES_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$FIXTURES_DIR/../../.." && pwd)"

--- a/tests/fixtures/normalize-constraints/verify-normalize.sh
+++ b/tests/fixtures/normalize-constraints/verify-normalize.sh
@@ -15,10 +15,10 @@ SCRIPT="$REPO_ROOT/scripts/normalize-constraints.py"
 echo "=== T-3 must_have_constraints normalize verify ==="
 echo
 
-python3 -c "import json; json.load(open('$FIXTURES_DIR/cases.json'))" >/dev/null \
+python3 -c "import json, sys; json.load(open(sys.argv[1]))" "$FIXTURES_DIR/cases.json" >/dev/null \
   || { echo "x cases.json malformed" >&2; exit 1; }
 
-case_count=$(python3 -c "import json; print(len(json.load(open('$FIXTURES_DIR/cases.json'))))")
+case_count=$(python3 -c "import json, sys; print(len(json.load(open(sys.argv[1]))))" "$FIXTURES_DIR/cases.json")
 
 fails=0
 for i in $(seq 0 $((case_count - 1))); do


### PR DESCRIPTION
## Summary

ComBba Phase 3 Part C — 5 final Test & CI Coverage items from umbrella #32. Closes umbrella with 1 deferral (T-7 → post-hackathon, see ASSESSMENT.md).

### T-2 — \`_filled_ratio\` reference + CI fixture
- \`scripts/compute-filled-ratio.py\`: single source of truth for the 9-slot rule in \`idea-spec.schema.json\`. Implements binary nested-object slot rule, 'unknown' filtering, array-length ≥1 rule.
- \`tests/fixtures/filled-ratio/cases.json\` — **7 cases** covering: B-3 skip (1/9 ≈ 0.1111), B-1 fast path (5/9 ≈ 0.5556), full path (9/9 = 1.0), nested-all-null, leaf-'unknown', empty-array, bool-false.
- Verify script asserts script output matches expected to 4 decimal places.

### T-3 — \`must_have_constraints\` normalize + schema enum
- \`scripts/normalize-constraints.py\`: maps user-facing labels per idea-clarifier.md Batch C table. Free-form input → \`type: \"other\"\`.
- Schema \`must_have_constraints.items.type\` gains \`enum: [\"regulatory\",\"budget\",\"latency\",\"team_size\",\"platform\",\"data_residency\",\"other\"]\` (7 canonical).
- \`tests/fixtures/normalize-constraints/cases.json\` — **13 cases** including canonical buckets with/without inline value, freeform Korean/English, edge cases (empty, whitespace, mismatched parens, uppercase).
- All existing fixtures (rule9-fp-guard, runs/_fixture) continue to validate.

### T-8 — LESSON 0.7 regression fixture
- New \`tests/fixtures/lesson07-regression/\` proves Rule 9 anchors on \`chosen_preview\` (user's H1 pick), not panel composite_winner.
- **2 cases**: respect P10 user pick when composite was P02 (exit 0); block drift toward P02 Slack-bot vocabulary when chosen_preview is P10 (exit 2).
- Closes coverage gap from LESSON 0.7's narrative regression scenario.

### T-12 — macOS CI matrix (Windows deferred)
- \`verify-plugin\` job converted to \`[ubuntu-latest, macos-14]\` matrix. macOS catches BSD-vs-GNU userland divergence (mktemp/sed/find) that ubuntu-only CI missed in PR #45.
- Windows defer rationale in ASSESSMENT.md.

### T-7 — deferred (assessment in \`tests/fixtures/ASSESSMENT.md\`)
- Mock UX harness for AskUserQuestion replay: 1–2 day build cost + sharp maintenance risk during agent-prompt iteration. Marginal value over the 5 artifact fixtures is moderate, not critical for hackathon.
- Re-open trigger documented (Socratic-flow regression slipping past artifact fixtures).

## CI integration
\`\`\`bash
bash tests/fixtures/security/verify-security.sh           # 13 sections
bash tests/fixtures/rule9-fp-guard/verify-rule9.sh        # 3 cases
bash tests/fixtures/filled-ratio/verify-filled-ratio.sh   # 7 cases  ← NEW
bash tests/fixtures/normalize-constraints/verify-normalize.sh  # 13 cases  ← NEW
bash tests/fixtures/lesson07-regression/verify-lesson07.sh # 2 cases  ← NEW
\`\`\`

All 5 suites green on local Ubuntu macOS pre-push.

## Closes
- Umbrella #32 P3 Test & CI Coverage (T-1/T-4/T-5/T-6/T-9/T-10/T-11 already shipped; T-2/T-3/T-8/T-12 in this PR; T-7 deferred per ASSESSMENT.md).

## Remaining work
- P8 Requirements Expansion (umbrella #37, 9 items) — last v1.7 audit umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * macOS 환경에서 CI 테스트 실행 지원 추가
  * 제약 조건 정규화 기능 추가

* **테스트**
  * 채움 비율 검증 테스트 추가
  * 제약 조건 정규화 테스트 추가
  * Lesson 0.7 회귀 테스트 추가

* **문서**
  * Phase 3 평가 및 진행 상황 문서 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->