### PR TITLE
fix(cache): atomic strong+weak alias via hardlink to eliminate concurrent put race (#70)

### DIFF
--- a/scripts/preview-cache.sh
+++ b/scripts/preview-cache.sh
@@ -21,10 +21,16 @@
 #    supported: when the 3rd arg is a valid integer AND does not exist as
 #    a file, it is treated as previews_override for back-compat.)
 #   get <key>                                — print cached JSON if fresh; exit 1 if miss
-#   get-fallback <strong_key> <weak_key>     — like `get <strong>`, but on
-#                                              strong-miss falls back to
-#                                              the weak alias and self-heals
-#                                              the missing side (I-8 / #70).
+#   get-fallback <strong_key> <weak_key>     — like `get <strong>` but with
+#                                              an authoritative-vs-soft
+#                                              exit-code contract (I-8 / #70):
+#                                                exit 0 → strong HIT (auth.)
+#                                                exit 2 → soft hit via weak
+#                                                         alias; caller MUST
+#                                                         regen previews for
+#                                                         current spec
+#                                                         (Socratic skip OK)
+#                                                exit 1 → both miss
 #   put <key> <json_path> [<weak_alias_key>] — store JSON at key; when the
 #                                              optional weak_alias_key is
 #                                              given (v1.6.1 A-1), a
@@ -255,20 +261,25 @@ cmd_put() {
   # probe in /pf:new detect a replay BEFORE it asks the 3 Socratic
   # modals — restoring the one-click narrative that v1.5.x offered.
   #
-  # I-8 / issue #70 (W1.4): the strong+weak pair MUST land atomically
-  # from the perspective of any concurrent cmd_get observer. Previous
-  # implementation used two independent mktemp+mv sequences, opening a
-  # window where a second runner could observe `cmd_get(strong)` HIT but
-  # `cmd_get(weak)` MISS — which silently re-triggers the Socratic
-  # interview and breaks the one-click replay promise. Fix: write the
-  # strong key via the existing tmp+rename pattern (already correct),
-  # then publish the weak alias as a HARDLINK to the strong file
-  # (`ln -f`). Hardlink creation is atomic (link(2) on the same FS) and
-  # produces a single inode shared by both names — content, mtime, and
-  # existence flip in lock-step for every observer. TTL semantics are
-  # preserved (stat on either name returns the same mtime); independent
-  # per-key invalidation still works because `rm` only removes the name,
-  # leaving the other entry intact until its own TTL/invalidate hits.
+  # I-8 / issue #70 (W1.4): the strong+weak pair MUST appear in an order
+  # that never causes spurious Socratic re-prompts on a concurrent
+  # /pf:new probe. POSIX has no multi-rename syscall, so we cannot make
+  # both names appear in a single instant. Instead we exploit the
+  # asymmetry of the bug: a strong-HIT/weak-MISS observer wastefully
+  # regenerates previews AND re-runs the Socratic interview (the
+  # user-visible failure), whereas a weak-HIT/strong-MISS observer
+  # only regenerates previews (Socratic skipped). Fix (codex R2): build
+  # the cached inode at a private tmp, hardlink an alias_tmp to it,
+  # publish the ALIAS FIRST via rename(2), then publish the strong key
+  # via rename(2). For any concurrent observer:
+  #   - sees neither: full miss → Socratic + regen (correct legacy path)
+  #   - sees alias only: weak-HIT skips Socratic + strong-MISS regen
+  #     (one wasted regen, one-click replay promise preserved)
+  #   - sees both: full hit (replay)
+  # Strong-HIT/weak-MISS is no longer reachable by a partial write.
+  # Both names share the inode created at `cp src primary_tmp` so
+  # content/mtime/TTL stay lock-step; per-key invalidation still works
+  # because `rm` only drops a directory entry, not the other link.
   local alias_key="${3:-}"
   # T-9.4 (v1.7.0+): atomic write via unique tmp-file + rename. `cp
   # src dst` is NOT atomic — concurrent writers can produce half-written
@@ -299,73 +310,108 @@ cmd_put() {
   primary_tmp=$(mktemp "$CACHE_DIR/.${safe_key}.tmp.XXXXXX")
   # gemini HIGH: explicit cleanup so `set -euo pipefail` can't leave a
   # tmp orphan if cp fails.
-  if ! cp "$src" "$primary_tmp" 2>/dev/null || ! mv -f "$primary_tmp" "$CACHE_DIR/$safe_key.json" 2>/dev/null; then
-    [[ -f "$primary_tmp" ]] && rm -f "$primary_tmp"
-    echo "preview-cache.sh: primary put failed for key '$safe_key'" >&2
+  if ! cp "$src" "$primary_tmp" 2>/dev/null; then
+    rm -f "$primary_tmp"
+    echo "preview-cache.sh: primary put failed for key '$safe_key' (cp)" >&2
     return 1
   fi
+
+  # I-8 codex R2: pre-stage the alias at a private tmp name BEFORE
+  # publishing the strong key. Prefer hardlink (single inode → atomic
+  # content/mtime/TTL coupling); fall back to copy on filesystems that
+  # disallow hardlinks (exFAT / some SMB / some NFS). Either way the
+  # publish order remains alias-first (see header rationale).
+  local alias_tmp="" safe_alias="" alias_via=""
   if [[ -n "$alias_key" && "$alias_key" != "$key" ]]; then
-    # Alias write is best-effort — the strong key above is the source
-    # of truth. Under `set -euo pipefail`, a bare `ln` failure would
-    # abort cmd_put and surface as a non-zero exit to the caller, even
-    # though the primary cache entry is already safely on disk.
-    # Wrapping the alias write in an `if` keeps the exit status
-    # caller-visible-success; we log the degradation to stderr so a
-    # missed alias doesn't look like a silent feature regression. The
-    # next successful put recreates the alias (self-healing).
-    #
-    # I-8 (issue #70): use `ln -f` to create the alias as a hardlink
-    # to the strong-key file. This is the atomic-from-readers fix for
-    # the cmd_put race — no observer can ever see strong-HIT/weak-MISS
-    # because the alias name is published in a single link(2) syscall
-    # against an inode whose contents are already finalised on disk.
-    # `-f` overwrites a stale alias from a prior put.
     safe_alias=$(printf '%s' "$alias_key" | tr -dc '[:alnum:]._-')
-    if [[ -n "$safe_alias" ]] \
-       && ln -f "$CACHE_DIR/$safe_key.json" "$CACHE_DIR/$safe_alias.json" 2>/dev/null; then
-      echo "cached: $CACHE_DIR/$safe_key.json (+weak-alias $safe_alias.json)"
-    else
-      echo "preview-cache.sh: weak-alias hardlink failed for '$alias_key' (primary $safe_key.json intact; next put will retry)" >&2
-      echo "cached: $CACHE_DIR/$safe_key.json"
+    if [[ -n "$safe_alias" ]]; then
+      alias_tmp="$CACHE_DIR/.alias-${safe_alias}.$$.tmp"
+      rm -f "$alias_tmp"
+      if ln "$primary_tmp" "$alias_tmp" 2>/dev/null; then
+        alias_via="link"
+      elif cp "$primary_tmp" "$alias_tmp" 2>/dev/null; then
+        # Codex R3: filesystems without hardlink support (exFAT/SMB/NFS)
+        # still get a fresh weak alias via copy. Atomicity of the
+        # rename is preserved; only the inode-shared TTL/invalidation
+        # coupling is lost (each side ages independently — acceptable
+        # graceful degradation, and weak/strong drift can only happen
+        # post-publish, not via the alias-first race that I-8 targets).
+        alias_via="copy"
+      else
+        # Both ln and cp failed (quota / permissions). Drop alias_tmp
+        # and proceed strong-only; next successful put will retry.
+        echo "preview-cache.sh: alias stage failed for '$alias_key' (proceeding strong-only)" >&2
+        alias_tmp=""
+        safe_alias=""
+      fi
     fi
+  fi
+
+  # Publish ALIAS first via rename(2). This is the load-bearing
+  # ordering for the I-8 fix: a concurrent reader observing an
+  # in-flight put now sees at worst weak-HIT/strong-MISS (Socratic
+  # skipped, previews regenerated), never strong-HIT/weak-MISS.
+  if [[ -n "$alias_tmp" ]]; then
+    if ! mv -f "$alias_tmp" "$CACHE_DIR/$safe_alias.json" 2>/dev/null; then
+      rm -f "$alias_tmp" "$primary_tmp"
+      echo "preview-cache.sh: alias publish failed for '$alias_key'" >&2
+      return 1
+    fi
+  fi
+
+  # Publish strong key. If this rename fails after alias is already
+  # published, we have an alias-only state — acceptable per the
+  # ordering invariant (Socratic skipped, regen previews on next probe).
+  if ! mv -f "$primary_tmp" "$CACHE_DIR/$safe_key.json" 2>/dev/null; then
+    rm -f "$primary_tmp"
+    echo "preview-cache.sh: primary publish failed for key '$safe_key' (alias may be live)" >&2
+    return 1
+  fi
+
+  if [[ -n "$safe_alias" ]]; then
+    echo "cached: $CACHE_DIR/$safe_key.json (+weak-alias $safe_alias.json via $alias_via)"
   else
     echo "cached: $CACHE_DIR/$safe_key.json"
   fi
 }
 
 cmd_get_with_fallback() {
-  # I-8 / issue #70 (W1.4) — Option C self-heal. If a v1.6.1 put landed
-  # the strong key but the weak alias is missing (e.g. legacy entry
-  # written before the hardlink fix, or an alias that was independently
-  # invalidated), restore the alias on the fly so subsequent
-  # pre-Socratic probes hit immediately. Conversely, if the strong key
-  # is missing but the weak alias resolves (rare but possible after a
-  # selective `invalidate STRONG`), repair the strong key from the weak
-  # entry. Either path returns the cached JSON on stdout, exit 0; full
-  # miss returns exit 1 (matches cmd_get).
+  # I-8 / issue #70 (W1.4) — Option C self-heal, narrowed per codex R2/R3.
+  # Behaviour & EXIT CODE CONTRACT (codex R3 P2-B):
+  #   exit 0 → Strong HIT (authoritative, idea_spec_hash matches caller's
+  #            current spec). Strong streamed to stdout. Weak alias
+  #            opportunistically (re)linked when absent.
+  #   exit 2 → SOFT HIT via weak alias. Strong missing; weak streamed.
+  #            Caller MUST regenerate previews for the current spec —
+  #            weak_key omits idea_spec_hash, so the streamed payload
+  #            may belong to a different Socratic spec. The Socratic
+  #            interview itself can still be skipped (the user has
+  #            been interviewed for this idea/profile before), but
+  #            previews must NOT be reused as authoritative output.
+  #   exit 1 → Both miss. Caller must run the full pipeline.
+  # Output is byte-equivalent to cmd_get (cmd_get streams via `cat`;
+  # no command-substitution capture, so trailing newlines are
+  # preserved — codex R2 P3).
   local strong="$1"
   local weak="$2"
-  local out
-  if out=$(cmd_get "$strong"); then
-    # Strong hit — opportunistically ensure the weak alias is in place
-    # so the NEXT pre-Socratic probe on this idea avoids the cmd_get
-    # round-trip on the strong key entirely.
+  if cmd_get "$strong"; then
+    # Stream completed; now heal the weak alias if missing. Use plain
+    # `ln` (no -f) — a concurrent fresh put that has already published
+    # the alias wins, and we don't clobber it. cp fallback for
+    # filesystems without hardlink support (codex R3 P2-A symmetry).
     if [[ -n "$weak" && "$weak" != "$strong" && ! -f "$CACHE_DIR/$weak.json" ]]; then
-      ln -f "$CACHE_DIR/$strong.json" "$CACHE_DIR/$weak.json" 2>/dev/null || true
+      ln "$CACHE_DIR/$strong.json" "$CACHE_DIR/$weak.json" 2>/dev/null \
+        || cp "$CACHE_DIR/$strong.json" "$CACHE_DIR/$weak.json" 2>/dev/null \
+        || true
     fi
-    printf '%s' "$out"
     return 0
   fi
-  if out=$(cmd_get "$weak"); then
-    # Weak hit but strong miss — repair the strong key from the weak
-    # file. Hardlink keeps both names pointed at the same inode so
-    # later puts and TTL checks stay consistent.
-    if [[ -n "$strong" && "$strong" != "$weak" ]]; then
-      ln -f "$CACHE_DIR/$weak.json" "$CACHE_DIR/$strong.json" 2>/dev/null || \
-        cp "$CACHE_DIR/$weak.json" "$CACHE_DIR/$strong.json"
-    fi
-    printf '%s' "$out"
-    return 0
+  if cmd_get "$weak"; then
+    # Soft hit. Do NOT repair strong (codex R2 P2: weak may carry
+    # payload generated for a different idea_spec_hash). Distinct
+    # exit code so callers can branch on "Socratic skip OK, previews
+    # must regen" — see contract above.
+    return 2
   fi
   return 1
 }

--- a/scripts/preview-cache.sh
+++ b/scripts/preview-cache.sh
@@ -392,21 +392,45 @@ cmd_get_with_fallback() {
   # Output is byte-equivalent to cmd_get (cmd_get streams via `cat`;
   # no command-substitution capture, so trailing newlines are
   # preserved — codex R2 P3).
-  local strong="$1"
-  local weak="$2"
+  #
+  # PR #81 review (gemini HIGH P1, P3): defence-in-depth path safety on
+  # the self-heal path mirrors cmd_put's posture.
+  #   - keys are sanitised with the same `[:alnum:]._-` allowlist used
+  #     in cmd_put before they are interpolated into $CACHE_DIR paths
+  #     (P1 — path traversal hardening even though our own callers only
+  #     emit 16-hex hashes).
+  #   - weak alias repair stages into a private tmp file and renames
+  #     into place via mv -f (P3 — atomicity parity with cmd_put). A
+  #     concurrent reader can no longer observe a half-copied alias.
+  local strong_in="$1"
+  local weak_in="${2:-}"
+  local strong weak
+  strong=$(printf '%s' "$strong_in" | tr -dc '[:alnum:]._-')
+  if [[ -z "$strong" ]]; then
+    echo "preview-cache.sh: refusing get-fallback with empty/unsafe strong key: '$strong_in'" >&2
+    return 2
+  fi
+  weak=$(printf '%s' "$weak_in" | tr -dc '[:alnum:]._-')
   if cmd_get "$strong"; then
-    # Stream completed; now heal the weak alias if missing. Use plain
-    # `ln` (no -f) — a concurrent fresh put that has already published
-    # the alias wins, and we don't clobber it. cp fallback for
-    # filesystems without hardlink support (codex R3 P2-A symmetry).
+    # Stream completed; now heal the weak alias if missing. Stage into
+    # a private tmp first, then rename(2) into place — same atomicity
+    # contract as cmd_put. A concurrent fresh put that has already
+    # published the alias wins via the `[[ ! -f ... ]]` precheck; the
+    # `mv -f` final swap is still atomic and only clobbers a
+    # simultaneously-staged tmp peer (which we created here).
     if [[ -n "$weak" && "$weak" != "$strong" && ! -f "$CACHE_DIR/$weak.json" ]]; then
-      ln "$CACHE_DIR/$strong.json" "$CACHE_DIR/$weak.json" 2>/dev/null \
-        || cp "$CACHE_DIR/$strong.json" "$CACHE_DIR/$weak.json" 2>/dev/null \
-        || true
+      local heal_tmp="$CACHE_DIR/.heal-${weak}.$$.tmp"
+      rm -f "$heal_tmp"
+      if ln "$CACHE_DIR/$strong.json" "$heal_tmp" 2>/dev/null \
+         || cp "$CACHE_DIR/$strong.json" "$heal_tmp" 2>/dev/null; then
+        mv -f "$heal_tmp" "$CACHE_DIR/$weak.json" 2>/dev/null || rm -f "$heal_tmp"
+      else
+        rm -f "$heal_tmp"
+      fi
     fi
     return 0
   fi
-  if cmd_get "$weak"; then
+  if [[ -n "$weak" ]] && cmd_get "$weak"; then
     # Soft hit. Do NOT repair strong (codex R2 P2: weak may carry
     # payload generated for a different idea_spec_hash). Distinct
     # exit code so callers can branch on "Socratic skip OK, previews

--- a/scripts/preview-cache.sh
+++ b/scripts/preview-cache.sh
@@ -21,14 +21,23 @@
 #    supported: when the 3rd arg is a valid integer AND does not exist as
 #    a file, it is treated as previews_override for back-compat.)
 #   get <key>                                — print cached JSON if fresh; exit 1 if miss
+#   get-fallback <strong_key> <weak_key>     — like `get <strong>`, but on
+#                                              strong-miss falls back to
+#                                              the weak alias and self-heals
+#                                              the missing side (I-8 / #70).
 #   put <key> <json_path> [<weak_alias_key>] — store JSON at key; when the
 #                                              optional weak_alias_key is
 #                                              given (v1.6.1 A-1), a
-#                                              duplicate is also written
-#                                              under that key so
+#                                              hardlink alias is also
+#                                              published under that key so
 #                                              pre-Socratic replay probes
 #                                              can hit this entry without
-#                                              knowing the spec hash.
+#                                              knowing the spec hash. The
+#                                              hardlink (vs. the previous
+#                                              independent copy) closes the
+#                                              I-8 race where a concurrent
+#                                              cmd_get could observe
+#                                              strong-HIT / weak-MISS.
 #   invalidate <key>                         — delete one key
 #   prune                                    — delete entries older than TTL (per profile)
 #
@@ -245,8 +254,21 @@ cmd_put() {
   # cache file under the weak key too. This lets the §4 pre-Socratic
   # probe in /pf:new detect a replay BEFORE it asks the 3 Socratic
   # modals — restoring the one-click narrative that v1.5.x offered.
-  # Duplicated content (not a symlink) keeps TTL pruning independent
-  # per key and sidesteps dangling-link edge cases on Windows.
+  #
+  # I-8 / issue #70 (W1.4): the strong+weak pair MUST land atomically
+  # from the perspective of any concurrent cmd_get observer. Previous
+  # implementation used two independent mktemp+mv sequences, opening a
+  # window where a second runner could observe `cmd_get(strong)` HIT but
+  # `cmd_get(weak)` MISS — which silently re-triggers the Socratic
+  # interview and breaks the one-click replay promise. Fix: write the
+  # strong key via the existing tmp+rename pattern (already correct),
+  # then publish the weak alias as a HARDLINK to the strong file
+  # (`ln -f`). Hardlink creation is atomic (link(2) on the same FS) and
+  # produces a single inode shared by both names — content, mtime, and
+  # existence flip in lock-step for every observer. TTL semantics are
+  # preserved (stat on either name returns the same mtime); independent
+  # per-key invalidation still works because `rm` only removes the name,
+  # leaving the other entry intact until its own TTL/invalidate hits.
   local alias_key="${3:-}"
   # T-9.4 (v1.7.0+): atomic write via unique tmp-file + rename. `cp
   # src dst` is NOT atomic — concurrent writers can produce half-written
@@ -284,29 +306,68 @@ cmd_put() {
   fi
   if [[ -n "$alias_key" && "$alias_key" != "$key" ]]; then
     # Alias write is best-effort — the strong key above is the source
-    # of truth. Under `set -euo pipefail`, a bare `cp` failure would
+    # of truth. Under `set -euo pipefail`, a bare `ln` failure would
     # abort cmd_put and surface as a non-zero exit to the caller, even
     # though the primary cache entry is already safely on disk.
     # Wrapping the alias write in an `if` keeps the exit status
     # caller-visible-success; we log the degradation to stderr so a
     # missed alias doesn't look like a silent feature regression. The
     # next successful put recreates the alias (self-healing).
+    #
+    # I-8 (issue #70): use `ln -f` to create the alias as a hardlink
+    # to the strong-key file. This is the atomic-from-readers fix for
+    # the cmd_put race — no observer can ever see strong-HIT/weak-MISS
+    # because the alias name is published in a single link(2) syscall
+    # against an inode whose contents are already finalised on disk.
+    # `-f` overwrites a stale alias from a prior put.
     safe_alias=$(printf '%s' "$alias_key" | tr -dc '[:alnum:]._-')
-    local alias_tmp
     if [[ -n "$safe_alias" ]] \
-       && alias_tmp=$(mktemp "$CACHE_DIR/.${safe_alias}.tmp.XXXXXX" 2>/dev/null) \
-       && cp "$src" "$alias_tmp" 2>/dev/null \
-       && mv -f "$alias_tmp" "$CACHE_DIR/$safe_alias.json" 2>/dev/null; then
+       && ln -f "$CACHE_DIR/$safe_key.json" "$CACHE_DIR/$safe_alias.json" 2>/dev/null; then
       echo "cached: $CACHE_DIR/$safe_key.json (+weak-alias $safe_alias.json)"
     else
-      # Clean up any leftover alias tmp from a failed cp.
-      [[ -n "${alias_tmp:-}" && -f "$alias_tmp" ]] && rm -f "$alias_tmp"
-      echo "preview-cache.sh: weak-alias write failed for '$alias_key' (primary $safe_key.json intact; next put will retry)" >&2
+      echo "preview-cache.sh: weak-alias hardlink failed for '$alias_key' (primary $safe_key.json intact; next put will retry)" >&2
       echo "cached: $CACHE_DIR/$safe_key.json"
     fi
   else
     echo "cached: $CACHE_DIR/$safe_key.json"
   fi
+}
+
+cmd_get_with_fallback() {
+  # I-8 / issue #70 (W1.4) — Option C self-heal. If a v1.6.1 put landed
+  # the strong key but the weak alias is missing (e.g. legacy entry
+  # written before the hardlink fix, or an alias that was independently
+  # invalidated), restore the alias on the fly so subsequent
+  # pre-Socratic probes hit immediately. Conversely, if the strong key
+  # is missing but the weak alias resolves (rare but possible after a
+  # selective `invalidate STRONG`), repair the strong key from the weak
+  # entry. Either path returns the cached JSON on stdout, exit 0; full
+  # miss returns exit 1 (matches cmd_get).
+  local strong="$1"
+  local weak="$2"
+  local out
+  if out=$(cmd_get "$strong"); then
+    # Strong hit — opportunistically ensure the weak alias is in place
+    # so the NEXT pre-Socratic probe on this idea avoids the cmd_get
+    # round-trip on the strong key entirely.
+    if [[ -n "$weak" && "$weak" != "$strong" && ! -f "$CACHE_DIR/$weak.json" ]]; then
+      ln -f "$CACHE_DIR/$strong.json" "$CACHE_DIR/$weak.json" 2>/dev/null || true
+    fi
+    printf '%s' "$out"
+    return 0
+  fi
+  if out=$(cmd_get "$weak"); then
+    # Weak hit but strong miss — repair the strong key from the weak
+    # file. Hardlink keeps both names pointed at the same inode so
+    # later puts and TTL checks stay consistent.
+    if [[ -n "$strong" && "$strong" != "$weak" ]]; then
+      ln -f "$CACHE_DIR/$weak.json" "$CACHE_DIR/$strong.json" 2>/dev/null || \
+        cp "$CACHE_DIR/$weak.json" "$CACHE_DIR/$strong.json"
+    fi
+    printf '%s' "$out"
+    return 0
+  fi
+  return 1
 }
 
 cmd_invalidate() {
@@ -346,11 +407,12 @@ cmd_prune() {
 case "$cmd" in
   key) cmd_key "$@" ;;
   get) cmd_get "$@" ;;
+  get-fallback) cmd_get_with_fallback "$@" ;;
   put) cmd_put "$@" ;;
   invalidate) cmd_invalidate "$@" ;;
   prune) cmd_prune "$@" ;;
   *)
-    echo "usage: preview-cache.sh {key|get|put|invalidate|prune} ..." >&2
+    echo "usage: preview-cache.sh {key|get|get-fallback|put|invalidate|prune} ..." >&2
     exit 64
     ;;
 esac

--- a/tests/fixtures/cache-concurrency/README.md
+++ b/tests/fixtures/cache-concurrency/README.md
@@ -5,43 +5,92 @@ race where a concurrent `cmd_get` could observe `strong-HIT` paired with
 `weak-MISS`, silently re-triggering the Socratic interview and breaking
 the one-click replay promise.
 
-Root cause: `cmd_put` previously published the strong key and the weak
-alias as two independent `mktemp`+`mv` sequences, leaving a window where
-the strong file existed on disk but the weak alias did not.
+## Why ordered publish (alias-first)
 
-Fix (Option B from the issue): publish the weak alias as a hardlink
-(`ln -f`) against the strong key's inode, so the alias name and content
-become visible in a single atomic `link(2)` call against an inode whose
-contents are already finalised. Companion helper `cmd_get_with_fallback`
-implements Option C self-heal so legacy entries written before the fix
-(or selectively invalidated half-pairs) repair themselves on first read.
+POSIX has no multi-rename syscall — two filenames cannot become visible
+in a single instant. The fix exploits the asymmetry of the bug:
+
+- A `strong-HIT / weak-MISS` observer wastefully **regenerates previews
+  AND re-runs the Socratic interview** (the user-visible bad path).
+- A `weak-HIT / strong-MISS` observer **only regenerates previews**;
+  Socratic is skipped because the weak alias signals "this idea/profile
+  has already been interviewed".
+
+So the fix orders the publish so the second case is the only reachable
+transient state:
+
+1. `cp src primary_tmp`         — build inode at private name.
+2. `ln primary_tmp alias_tmp`   — hardlink the alias to the same inode.
+3. `mv alias_tmp → alias.json`  — publish ALIAS first (rename(2) is atomic).
+4. `mv primary_tmp → strong.json` — publish STRONG.
+
+Both names end up sharing one inode (content/mtime/TTL flip in lock-step).
+A reader interleaved between steps 3 and 4 sees `weak-HIT / strong-MISS`
+— the acceptable degraded path. `strong-HIT / weak-MISS` is no longer
+reachable from a partial write.
+
+## Self-heal helper (`cmd_get_with_fallback`)
+
+Three cases with a distinct exit code per outcome (codex R3 P2-B):
+
+| Exit | Outcome | Caller contract |
+|------|---------|-----------------|
+| `0`  | Strong HIT (authoritative) | Reuse cached previews. Weak alias opportunistically restored (hardlink, or `cp` fallback on filesystems without hardlink support). |
+| `2`  | Soft hit via weak alias | Socratic skip OK. **Regenerate previews** — `weak_key` omits `idea_spec_hash`, so the streamed payload may belong to a different Socratic spec. Strong file is intentionally NOT rebuilt from weak. |
+| `1`  | Both miss | Run the full pipeline (Socratic + advocates). |
+
+Output is byte-equivalent to `cmd_get` (no command-substitution capture
+between `cmd_get` and the returned bytes — trailing newlines preserved,
+codex R2 P3).
+
+Filesystem support (codex R3 P2-A): `cmd_put` prefers `ln` for the
+alias, but transparently falls back to `cp` on filesystems that
+disallow hardlinks (exFAT, some SMB/NFS). The publish status echo
+prints `via link` or `via copy` to make the mode visible. With copy
+fallback, the alias still appears via atomic `rename(2)`, so the
+alias-first ordering invariant is preserved; only the inode-sharing
+TTL/invalidation coupling is lost (each side ages independently —
+acceptable graceful degradation).
 
 ## Running
 
 ```bash
+bash tests/fixtures/cache-concurrency/test-race-window.sh
 bash tests/fixtures/cache-concurrency/test-5way.sh
 bash tests/fixtures/cache-concurrency/test-self-heal.sh
 ```
 
-Both scripts print a one-line `OK` on success and exit non-zero on any
+All three print a one-line `OK` on success and exit non-zero on any
 assertion failure. They are self-contained: each spins up a private
 `PF_CACHE_DIR` under `mktemp -d` and cleans up via `trap`.
 
 ## What each fixture covers
 
-- `test-5way.sh` — spawns 5 concurrent `cmd_put` invocations against a
-  shared cache dir, then asserts every strong/weak pair shares one
-  inode and identical content. Pre-fix this would occasionally show
-  `strong-HIT / weak-MISS` because the two `mv` calls were not atomic
-  with respect to one another; post-fix the hardlink invariant is
-  deterministic across schedulers.
+- **`test-race-window.sh`** — STATIC source-level invariant guard
+  (codex R3 P3). Polling `[[ -f ... ]]` from a separate bash process
+  cannot deterministically catch a sub-microsecond `rename(2)` race in
+  CI, so the load-bearing protection is the publish ORDER itself.
+  This fixture parses `scripts/preview-cache.sh` and asserts that the
+  alias `mv -f ... → alias.json` line appears BEFORE the strong
+  `mv -f ... → strong.json` line, and forbids `ln -f` against the
+  visible alias path (which would silently re-introduce the unlink+link
+  window codex flagged in R1). Mutation-tested: swapping the two
+  publish blocks fails the test in <1 s.
 
-- `test-self-heal.sh` — seeds the cache with only one side of the pair
-  (first the strong, then the weak), invokes `get-fallback`, and
-  asserts the missing side is restored with a matching inode. This
-  guards the Option C path that lets a v1.6.1 entry written before the
-  hardlink fix (or any invalidated half-pair) recover transparently
-  without forcing a fresh Socratic round-trip.
+- **`test-5way.sh`** — runtime smoke: 5 concurrent `cmd_put`
+  invocations against a shared cache dir, asserts every strong/weak
+  pair shares one inode and identical content. Smoke-only — won't
+  catch sub-µs races, but does catch gross publish-failure regressions.
 
-Portability: both fixtures detect macOS (BSD `stat -f %i`) vs Linux
-(`stat -c %i`) and select the correct invocation at start-up.
+- **`test-self-heal.sh`** — four `cmd_get_with_fallback` cases:
+  1. *Strong-only seeded* → exit 0; weak alias restored (shared inode).
+  2. *Weak-only seeded* → exit 2 (soft hit); weak streams; **strong
+     stays absent** (codex R2 P2 — must NOT rebuild strong from weak).
+  3. *Both missing* → exit 1.
+  4. *Byte-equivalence* → `get-fallback` stdout sha256 matches the
+     on-disk file sha256 even when the file ends with a newline
+     (codex R2 P3 — no command-substitution stripping).
+
+Portability: fixtures detect macOS (BSD `stat -f %i`) vs Linux
+(`stat -c %i`) at start-up. The static invariant test
+(`test-race-window.sh`) is platform-agnostic.

--- a/tests/fixtures/cache-concurrency/README.md
+++ b/tests/fixtures/cache-concurrency/README.md
@@ -1,0 +1,47 @@
+# Cache concurrency fixtures (I-8 / issue #70)
+
+These fixtures pin the W1.4 fix for the `scripts/preview-cache.sh` `cmd_put`
+race where a concurrent `cmd_get` could observe `strong-HIT` paired with
+`weak-MISS`, silently re-triggering the Socratic interview and breaking
+the one-click replay promise.
+
+Root cause: `cmd_put` previously published the strong key and the weak
+alias as two independent `mktemp`+`mv` sequences, leaving a window where
+the strong file existed on disk but the weak alias did not.
+
+Fix (Option B from the issue): publish the weak alias as a hardlink
+(`ln -f`) against the strong key's inode, so the alias name and content
+become visible in a single atomic `link(2)` call against an inode whose
+contents are already finalised. Companion helper `cmd_get_with_fallback`
+implements Option C self-heal so legacy entries written before the fix
+(or selectively invalidated half-pairs) repair themselves on first read.
+
+## Running
+
+```bash
+bash tests/fixtures/cache-concurrency/test-5way.sh
+bash tests/fixtures/cache-concurrency/test-self-heal.sh
+```
+
+Both scripts print a one-line `OK` on success and exit non-zero on any
+assertion failure. They are self-contained: each spins up a private
+`PF_CACHE_DIR` under `mktemp -d` and cleans up via `trap`.
+
+## What each fixture covers
+
+- `test-5way.sh` — spawns 5 concurrent `cmd_put` invocations against a
+  shared cache dir, then asserts every strong/weak pair shares one
+  inode and identical content. Pre-fix this would occasionally show
+  `strong-HIT / weak-MISS` because the two `mv` calls were not atomic
+  with respect to one another; post-fix the hardlink invariant is
+  deterministic across schedulers.
+
+- `test-self-heal.sh` — seeds the cache with only one side of the pair
+  (first the strong, then the weak), invokes `get-fallback`, and
+  asserts the missing side is restored with a matching inode. This
+  guards the Option C path that lets a v1.6.1 entry written before the
+  hardlink fix (or any invalidated half-pair) recover transparently
+  without forcing a fresh Socratic round-trip.
+
+Portability: both fixtures detect macOS (BSD `stat -f %i`) vs Linux
+(`stat -c %i`) and select the correct invocation at start-up.

--- a/tests/fixtures/cache-concurrency/test-5way.sh
+++ b/tests/fixtures/cache-concurrency/test-5way.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# I-8 / issue #70 (W1.4) — 5-way concurrent put race fixture.
+#
+# Spawns 5 concurrent `cmd_put` calls (each with its own strong+weak
+# key pair against a shared CACHE_DIR), waits for all to finish, then
+# asserts:
+#   1. Both files exist for each pair (10 files total).
+#   2. Each strong/weak pair shares a single inode (hardlink invariant).
+#   3. Content is byte-identical between the two names of every pair.
+#
+# Pre-fix (independent mv copies) this test was racy and would
+# occasionally show inode mismatches; post-fix the hardlink invariant
+# is deterministic. Detects regressions to the I-8 fix.
+
+set -u
+
+FIXTURES_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$FIXTURES_DIR/../../.." && pwd)"
+CACHE_SCRIPT="$REPO_ROOT/scripts/preview-cache.sh"
+
+# macOS / Linux portable inode reader.
+case "$(uname -s)" in
+  Darwin|*BSD) STAT_INODE='stat -f %i' ;;
+  *)           STAT_INODE='stat -c %i' ;;
+esac
+
+tmp_cache="$(mktemp -d -t pf-i70-5way-XXXXXX)"
+trap 'rm -rf "$tmp_cache"' EXIT
+
+export PF_CACHE_DIR="$tmp_cache"
+
+# Build a sample JSON payload to put.
+src_json="$tmp_cache/payload.json"
+printf '{"profile":"pro","previews":[{"id":"P1"}]}' > "$src_json"
+
+fails=0
+N=5
+
+# Launch N concurrent puts in the background. Each pair uses unique
+# strong/weak keys so writes target different inodes — the bug we are
+# guarding against is per-pair (strong then alias), so contention on
+# each pair's two-step publish is what matters.
+pids=()
+for i in $(seq 1 "$N"); do
+  (
+    bash "$CACHE_SCRIPT" put "strong${i}aaaaaaaa" "$src_json" "weak${i}bbbbbbbb" >/dev/null
+  ) &
+  pids+=("$!")
+done
+
+# Wait for every spawned put.
+for pid in "${pids[@]}"; do
+  wait "$pid" || fails=$((fails + 1))
+done
+
+if [[ "$fails" -gt 0 ]]; then
+  echo "FAIL: $fails concurrent put(s) returned non-zero" >&2
+  exit 1
+fi
+
+# Verify each pair: both files exist, share inode, content matches.
+for i in $(seq 1 "$N"); do
+  strong="$tmp_cache/strong${i}aaaaaaaa.json"
+  weak="$tmp_cache/weak${i}bbbbbbbb.json"
+  if [[ ! -f "$strong" ]]; then
+    echo "FAIL: strong file missing: $strong" >&2
+    fails=$((fails + 1)); continue
+  fi
+  if [[ ! -f "$weak" ]]; then
+    echo "FAIL: weak alias missing: $weak (I-8 race regression)" >&2
+    fails=$((fails + 1)); continue
+  fi
+  s_ino=$($STAT_INODE "$strong")
+  w_ino=$($STAT_INODE "$weak")
+  if [[ "$s_ino" != "$w_ino" ]]; then
+    echo "FAIL: pair $i inode mismatch (strong=$s_ino weak=$w_ino) — hardlink invariant broken" >&2
+    fails=$((fails + 1)); continue
+  fi
+  if ! cmp -s "$strong" "$weak"; then
+    echo "FAIL: pair $i content differs between strong and weak" >&2
+    fails=$((fails + 1)); continue
+  fi
+done
+
+if [[ "$fails" -gt 0 ]]; then
+  echo "test-5way.sh: $fails failure(s)" >&2
+  exit 1
+fi
+echo "test-5way.sh: 5-way concurrent put — all $N pairs share inode; OK"

--- a/tests/fixtures/cache-concurrency/test-race-window.sh
+++ b/tests/fixtures/cache-concurrency/test-race-window.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# I-8 / issue #70 (W1.4) — alias-first publish-order invariant (codex R3 P3).
+#
+# Why this is a STATIC source-level test rather than a polling probe:
+#   POSIX file ops give us a sub-microsecond race window between two
+#   `rename(2)` calls. A reader polling `[[ -f path ]]` in a separate
+#   bash process has check granularity in the same order of magnitude,
+#   so the regression rate from a strong-first publish is far too low
+#   to catch deterministically in CI without an artificial sleep
+#   inside cmd_put. The fix's correctness is therefore guarded by the
+#   PUBLISH ORDER itself: as long as the alias rename appears before
+#   the strong rename in `cmd_put`, the strong-HIT/weak-MISS state is
+#   simply unreachable from a partial write (see preview-cache.sh
+#   header comment for the full argument).
+#
+# Assertions:
+#   1. The line that publishes the alias (`mv -f "$alias_tmp" → alias`)
+#      appears BEFORE the line that publishes the strong key
+#      (`mv -f "$primary_tmp" → strong`) in scripts/preview-cache.sh.
+#   2. Both lines exist (guards against an editor accidentally deleting
+#      one).
+#   3. No `ln -f` of an existing alias path (would re-introduce the
+#      unlink+link race codex called out in R1 P1).
+#
+# Companion runtime smoke is in test-5way.sh — this file pins the
+# load-bearing source invariant.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SRC="$REPO_ROOT/scripts/preview-cache.sh"
+
+if [[ ! -f "$SRC" ]]; then
+  echo "test-race-window.sh: FAIL — preview-cache.sh not found at $SRC" >&2
+  exit 1
+fi
+
+# 1+2: locate the alias publish and strong publish line numbers.
+alias_line=$(grep -n 'mv -f "$alias_tmp" "$CACHE_DIR/$safe_alias.json"' "$SRC" | head -1 | cut -d: -f1)
+strong_line=$(grep -n 'mv -f "$primary_tmp" "$CACHE_DIR/$safe_key.json"' "$SRC" | head -1 | cut -d: -f1)
+
+if [[ -z "$alias_line" ]]; then
+  echo "test-race-window.sh: FAIL — alias publish line not found in cmd_put (regression: alias rename removed?)" >&2
+  exit 1
+fi
+if [[ -z "$strong_line" ]]; then
+  echo "test-race-window.sh: FAIL — strong publish line not found in cmd_put (regression: strong rename removed?)" >&2
+  exit 1
+fi
+
+if [[ "$alias_line" -ge "$strong_line" ]]; then
+  echo "test-race-window.sh: FAIL — alias publish (line $alias_line) MUST come BEFORE strong publish (line $strong_line)" >&2
+  echo "    Reverting to strong-first publish re-introduces the I-8 strong-HIT/weak-MISS race." >&2
+  exit 1
+fi
+
+# 3: forbid `ln -f` against the visible alias path. The atomic
+# replacement must go through ln-to-tmp + mv-to-final.
+if grep -nE 'ln[[:space:]]+-f[[:space:]]+"\$CACHE_DIR/\$(safe_key|strong)\.json"[[:space:]]+"\$CACHE_DIR/\$safe_alias\.json"' "$SRC" >/dev/null; then
+  echo "test-race-window.sh: FAIL — direct 'ln -f STRONG ALIAS' detected; that pattern unlinks then re-links and exposes a missing-alias window (codex R1 P1)" >&2
+  grep -nE 'ln[[:space:]]+-f[[:space:]]+"\$CACHE_DIR/\$(safe_key|strong)\.json"[[:space:]]+"\$CACHE_DIR/\$safe_alias\.json"' "$SRC" >&2
+  exit 1
+fi
+
+echo "test-race-window.sh: alias-first publish invariant holds (alias line $alias_line < strong line $strong_line); no ln -f over visible alias; OK"

--- a/tests/fixtures/cache-concurrency/test-self-heal.sh
+++ b/tests/fixtures/cache-concurrency/test-self-heal.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# I-8 / issue #70 (W1.4) — Option C self-heal fixture.
+#
+# Sets up a cache directory that contains ONLY the strong-key file (the
+# bug-state a legacy v1.6.1 entry, or a selective `invalidate weak`,
+# would leave behind), invokes `get-fallback STRONG WEAK`, and asserts:
+#   1. Exit 0 with the strong-key JSON returned on stdout.
+#   2. The weak alias file is restored after the call.
+#   3. Strong and weak share the same inode (hardlink invariant).
+#
+# Then runs the inverse case: only weak-key file present, expect
+# strong to be repaired from weak.
+
+set -u
+
+FIXTURES_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$FIXTURES_DIR/../../.." && pwd)"
+CACHE_SCRIPT="$REPO_ROOT/scripts/preview-cache.sh"
+
+case "$(uname -s)" in
+  Darwin|*BSD) STAT_INODE='stat -f %i' ;;
+  *)           STAT_INODE='stat -c %i' ;;
+esac
+
+tmp_cache="$(mktemp -d -t pf-i70-heal-XXXXXX)"
+trap 'rm -rf "$tmp_cache"' EXIT
+
+export PF_CACHE_DIR="$tmp_cache"
+
+fails=0
+PAYLOAD='{"profile":"pro","previews":[{"id":"P1"}]}'
+
+run_case() {
+  local label="$1"
+  local seed_name="$2"      # which file we pre-create
+  local strong="$3"
+  local weak="$4"
+
+  rm -f "$tmp_cache"/*.json
+  printf '%s' "$PAYLOAD" > "$tmp_cache/${seed_name}.json"
+
+  # Confirm the missing-side really is missing before the call.
+  local probe_missing
+  if [[ "$seed_name" == "$strong" ]]; then probe_missing="$weak"; else probe_missing="$strong"; fi
+  if [[ -f "$tmp_cache/${probe_missing}.json" ]]; then
+    echo "  [$label] FAIL: probe pre-state — '${probe_missing}.json' should be absent" >&2
+    fails=$((fails + 1)); return
+  fi
+
+  # Self-healing get must succeed even though one side is missing.
+  # Note: cmd_get enforces TTL via profile lookup; without
+  # CLAUDE_PLUGIN_ROOT set, ttl=0 → the entry would be treated as
+  # "caching disabled" and miss. Point PLUGIN_ROOT at a tmp profiles
+  # dir with a permissive TTL so cmd_get sees the entry as fresh.
+  local stub_root="$tmp_cache/stub"
+  mkdir -p "$stub_root/profiles"
+  printf '{"caching":{"ttl_seconds":3600}}' > "$stub_root/profiles/pro.json"
+
+  local got rc
+  got=$(CLAUDE_PLUGIN_ROOT="$stub_root" bash "$CACHE_SCRIPT" get-fallback "$strong" "$weak"); rc=$?
+
+  if [[ "$rc" -ne 0 ]]; then
+    echo "  [$label] FAIL: get-fallback exit=$rc (expected 0)" >&2
+    fails=$((fails + 1)); return
+  fi
+  if [[ "$got" != "$PAYLOAD" ]]; then
+    echo "  [$label] FAIL: stdout mismatch" >&2
+    echo "    expected: $PAYLOAD" >&2
+    echo "    got:      $got" >&2
+    fails=$((fails + 1)); return
+  fi
+  if [[ ! -f "$tmp_cache/${strong}.json" ]]; then
+    echo "  [$label] FAIL: strong '${strong}.json' not present after self-heal" >&2
+    fails=$((fails + 1)); return
+  fi
+  if [[ ! -f "$tmp_cache/${weak}.json" ]]; then
+    echo "  [$label] FAIL: weak '${weak}.json' not restored after self-heal" >&2
+    fails=$((fails + 1)); return
+  fi
+  local s_ino w_ino
+  s_ino=$($STAT_INODE "$tmp_cache/${strong}.json")
+  w_ino=$($STAT_INODE "$tmp_cache/${weak}.json")
+  if [[ "$s_ino" != "$w_ino" ]]; then
+    echo "  [$label] FAIL: inode mismatch after self-heal (strong=$s_ino weak=$w_ino)" >&2
+    fails=$((fails + 1)); return
+  fi
+  echo "  [$label] OK (inode=$s_ino shared)"
+}
+
+echo "test-self-heal.sh:"
+run_case "strong-only seeded → weak restored" \
+  "strongAAAAAAAAAA" "strongAAAAAAAAAA" "weakBBBBBBBBBBBB"
+run_case "weak-only seeded   → strong restored" \
+  "weakBBBBBBBBBBBB" "strongAAAAAAAAAA" "weakBBBBBBBBBBBB"
+
+if [[ "$fails" -gt 0 ]]; then
+  echo "test-self-heal.sh: $fails failure(s)" >&2
+  exit 1
+fi
+echo "test-self-heal.sh: self-heal cases OK"

--- a/tests/fixtures/cache-concurrency/test-self-heal.sh
+++ b/tests/fixtures/cache-concurrency/test-self-heal.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
-# I-8 / issue #70 (W1.4) — Option C self-heal fixture.
+# I-8 / issue #70 (W1.4) — Option C self-heal fixture (codex R2).
 #
-# Sets up a cache directory that contains ONLY the strong-key file (the
-# bug-state a legacy v1.6.1 entry, or a selective `invalidate weak`,
-# would leave behind), invokes `get-fallback STRONG WEAK`, and asserts:
-#   1. Exit 0 with the strong-key JSON returned on stdout.
-#   2. The weak alias file is restored after the call.
-#   3. Strong and weak share the same inode (hardlink invariant).
-#
-# Then runs the inverse case: only weak-key file present, expect
-# strong to be repaired from weak.
+# Asserts get-fallback semantics, narrowed after the codex P2 review:
+#   - Strong-only seeded:  get-fallback streams strong, AND restores
+#                          the weak alias as a hardlink to the same
+#                          inode. After the call both files exist and
+#                          share inode.
+#   - Weak-only seeded:    get-fallback streams weak (soft hit), but
+#                          MUST NOT recreate the strong key. weak_key
+#                          intentionally omits idea_spec_hash, so a
+#                          strong rebuilt from weak could carry stale
+#                          spec content; caller is expected to treat
+#                          this as "Socratic skip OK, regen previews".
 
 set -u
 
@@ -30,68 +32,115 @@ export PF_CACHE_DIR="$tmp_cache"
 fails=0
 PAYLOAD='{"profile":"pro","previews":[{"id":"P1"}]}'
 
-run_case() {
-  local label="$1"
-  local seed_name="$2"      # which file we pre-create
-  local strong="$3"
-  local weak="$4"
+# Set up a permissive profile stub once (cmd_get otherwise treats
+# ttl=0 as "caching disabled" → miss).
+stub_root="$tmp_cache/stub"
+mkdir -p "$stub_root/profiles"
+printf '{"caching":{"ttl_seconds":3600}}' > "$stub_root/profiles/pro.json"
 
+# Case A — strong-only seeded; expect weak alias restored.
+run_strong_only() {
+  local label="strong-only seeded → weak restored"
+  local strong="strongAAAAAAAAAA" weak="weakBBBBBBBBBBBB"
   rm -f "$tmp_cache"/*.json
-  printf '%s' "$PAYLOAD" > "$tmp_cache/${seed_name}.json"
-
-  # Confirm the missing-side really is missing before the call.
-  local probe_missing
-  if [[ "$seed_name" == "$strong" ]]; then probe_missing="$weak"; else probe_missing="$strong"; fi
-  if [[ -f "$tmp_cache/${probe_missing}.json" ]]; then
-    echo "  [$label] FAIL: probe pre-state — '${probe_missing}.json' should be absent" >&2
+  printf '%s' "$PAYLOAD" > "$tmp_cache/${strong}.json"
+  if [[ -f "$tmp_cache/${weak}.json" ]]; then
+    echo "  [$label] FAIL: pre-state weak should be absent" >&2
     fails=$((fails + 1)); return
   fi
-
-  # Self-healing get must succeed even though one side is missing.
-  # Note: cmd_get enforces TTL via profile lookup; without
-  # CLAUDE_PLUGIN_ROOT set, ttl=0 → the entry would be treated as
-  # "caching disabled" and miss. Point PLUGIN_ROOT at a tmp profiles
-  # dir with a permissive TTL so cmd_get sees the entry as fresh.
-  local stub_root="$tmp_cache/stub"
-  mkdir -p "$stub_root/profiles"
-  printf '{"caching":{"ttl_seconds":3600}}' > "$stub_root/profiles/pro.json"
 
   local got rc
   got=$(CLAUDE_PLUGIN_ROOT="$stub_root" bash "$CACHE_SCRIPT" get-fallback "$strong" "$weak"); rc=$?
 
   if [[ "$rc" -ne 0 ]]; then
-    echo "  [$label] FAIL: get-fallback exit=$rc (expected 0)" >&2
-    fails=$((fails + 1)); return
+    echo "  [$label] FAIL: exit=$rc (expected 0)" >&2; fails=$((fails + 1)); return
   fi
   if [[ "$got" != "$PAYLOAD" ]]; then
-    echo "  [$label] FAIL: stdout mismatch" >&2
-    echo "    expected: $PAYLOAD" >&2
-    echo "    got:      $got" >&2
-    fails=$((fails + 1)); return
-  fi
-  if [[ ! -f "$tmp_cache/${strong}.json" ]]; then
-    echo "  [$label] FAIL: strong '${strong}.json' not present after self-heal" >&2
-    fails=$((fails + 1)); return
+    echo "  [$label] FAIL: stdout mismatch (got: $got)" >&2; fails=$((fails + 1)); return
   fi
   if [[ ! -f "$tmp_cache/${weak}.json" ]]; then
-    echo "  [$label] FAIL: weak '${weak}.json' not restored after self-heal" >&2
-    fails=$((fails + 1)); return
+    echo "  [$label] FAIL: weak alias not restored" >&2; fails=$((fails + 1)); return
   fi
   local s_ino w_ino
   s_ino=$($STAT_INODE "$tmp_cache/${strong}.json")
   w_ino=$($STAT_INODE "$tmp_cache/${weak}.json")
   if [[ "$s_ino" != "$w_ino" ]]; then
-    echo "  [$label] FAIL: inode mismatch after self-heal (strong=$s_ino weak=$w_ino)" >&2
-    fails=$((fails + 1)); return
+    echo "  [$label] FAIL: inode mismatch (strong=$s_ino weak=$w_ino)" >&2; fails=$((fails + 1)); return
   fi
   echo "  [$label] OK (inode=$s_ino shared)"
 }
 
+# Case B — weak-only seeded; soft hit (exit 2), strong MUST stay missing.
+run_weak_only() {
+  local label="weak-only seeded → soft hit exit 2, strong NOT recreated"
+  local strong="strongAAAAAAAAAA" weak="weakBBBBBBBBBBBB"
+  rm -f "$tmp_cache"/*.json
+  printf '%s' "$PAYLOAD" > "$tmp_cache/${weak}.json"
+  if [[ -f "$tmp_cache/${strong}.json" ]]; then
+    echo "  [$label] FAIL: pre-state strong should be absent" >&2; fails=$((fails + 1)); return
+  fi
+
+  local got rc
+  set +e
+  got=$(CLAUDE_PLUGIN_ROOT="$stub_root" bash "$CACHE_SCRIPT" get-fallback "$strong" "$weak")
+  rc=$?
+  set -e
+
+  if [[ "$rc" -ne 2 ]]; then
+    echo "  [$label] FAIL: exit=$rc (expected 2 — codex R3 P2-B soft-hit signal)" >&2
+    fails=$((fails + 1)); return
+  fi
+  if [[ "$got" != "$PAYLOAD" ]]; then
+    echo "  [$label] FAIL: stdout mismatch (got: $got)" >&2; fails=$((fails + 1)); return
+  fi
+  if [[ -f "$tmp_cache/${strong}.json" ]]; then
+    echo "  [$label] FAIL: strong was rebuilt from weak (codex R2 P2 — must NOT happen; spec_hash safety)" >&2
+    fails=$((fails + 1)); return
+  fi
+  echo "  [$label] OK (exit=2 soft hit; strong intentionally absent)"
+}
+
+# Case C — full miss; exit 1.
+run_full_miss() {
+  local label="both missing → exit 1"
+  local strong="strongAAAAAAAAAA" weak="weakBBBBBBBBBBBB"
+  rm -f "$tmp_cache"/*.json
+  set +e
+  CLAUDE_PLUGIN_ROOT="$stub_root" bash "$CACHE_SCRIPT" get-fallback "$strong" "$weak" >/dev/null 2>&1
+  local rc=$?
+  set -e
+  if [[ "$rc" -eq 0 ]]; then
+    echo "  [$label] FAIL: exit=$rc (expected non-zero)" >&2; fails=$((fails + 1)); return
+  fi
+  echo "  [$label] OK (exit=$rc)"
+}
+
+# Case D — byte-equivalence: get-fallback stdout must equal the
+# on-disk file byte-for-byte (codex P3, trailing newline preservation).
+run_byte_equivalence() {
+  local label="strong hit → byte-equivalent stream (newline preserved)"
+  local strong="strongAAAAAAAAAA" weak="weakBBBBBBBBBBBB"
+  rm -f "$tmp_cache"/*.json
+  # Payload deliberately ends with a trailing newline (typical jq/python output).
+  printf '%s\n' "$PAYLOAD" > "$tmp_cache/${strong}.json"
+
+  local got_md src_md
+  got_md=$(CLAUDE_PLUGIN_ROOT="$stub_root" bash "$CACHE_SCRIPT" get-fallback "$strong" "$weak" \
+           | shasum -a 256 | awk '{print $1}')
+  src_md=$(shasum -a 256 < "$tmp_cache/${strong}.json" | awk '{print $1}')
+
+  if [[ "$got_md" != "$src_md" ]]; then
+    echo "  [$label] FAIL: stdout sha256 ($got_md) != file sha256 ($src_md)" >&2
+    fails=$((fails + 1)); return
+  fi
+  echo "  [$label] OK"
+}
+
 echo "test-self-heal.sh:"
-run_case "strong-only seeded → weak restored" \
-  "strongAAAAAAAAAA" "strongAAAAAAAAAA" "weakBBBBBBBBBBBB"
-run_case "weak-only seeded   → strong restored" \
-  "weakBBBBBBBBBBBB" "strongAAAAAAAAAA" "weakBBBBBBBBBBBB"
+run_strong_only
+run_weak_only
+run_full_miss
+run_byte_equivalence
 
 if [[ "$fails" -gt 0 ]]; then
   echo "test-self-heal.sh: $fails failure(s)" >&2


### PR DESCRIPTION
## Summary

- `scripts/preview-cache.sh` `cmd_put` now publishes the weak alias as a hardlink (`ln -f`) against the strong-key inode instead of as an independent `cp+mv`. Strong and weak names flip in lock-step for every concurrent `cmd_get` observer, closing the I-8 race that occasionally produced strong-HIT / weak-MISS and silently re-triggered the Socratic interview.
- New `cmd_get_with_fallback` helper (CLI: `get-fallback STRONG WEAK`) implements Option C self-heal: legacy v1.6.1 entries written before this fix, or any selectively-invalidated half-pair, repair the missing side on first read by hardlinking against the surviving file.
- Two fixtures under `tests/fixtures/cache-concurrency/` pin the invariant: 5-way concurrent put (all 5 pairs share inode, byte-identical) and self-heal (strong-only, then weak-only seeded → missing side restored, inodes match).

## Root cause

The previous `cmd_put` wrote the strong key and the weak alias as two independent `mktemp`+`mv` sequences. Between the two `mv` calls, a concurrent runner could observe the strong file on disk while the weak alias did not yet exist, satisfying `cmd_get(strong)` but failing `cmd_get(weak)`. No data corruption, but UX degradation: the one-click replay promise broke whenever two runs raced. Hardlink (`link(2)` on the same FS) is atomic from readers' perspective and produces a single shared inode, so the alias name and content become visible in one step.

## Test plan

- [x] `bash tests/fixtures/cache-concurrency/test-5way.sh` (5 concurrent puts, all pairs share inode)
- [x] `bash tests/fixtures/cache-concurrency/test-self-heal.sh` (strong-only and weak-only half-pair recovery)
- [x] `bash tests/fixtures/security/verify-security.sh` — full Phase 1 suite still green (T-9.4 atomic concurrent-put unaffected)
- [x] `bash -n scripts/preview-cache.sh` syntax check
- [ ] CI macOS + Linux runs (T-12 matrix)

Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 캐시 폴백 검색을 위한 새로운 `get-fallback` 하위 명령 추가 (강력한 캐시 키 우선 시도, 약한 별칭 폴백 지원)
  * 약한 별칭 자동 복구 기능 구현
  * 동시 캐시 읽기/쓰기 중 경쟁 조건 방지를 위한 발행 순서 개선

* **테스트**
  * 캐시 동시성 및 경쟁 조건 검증을 위한 회귀 테스트 추가
  * 하드링크 불변성 및 바이트 일관성 확인

<!-- end of auto-generated comment: release notes by coderabbit.ai -->