### PR TITLE
fix(security): SHELL_BYPASSES coverage + regex weakening probes (#64 #69)

### DIFF
--- a/plugins/preview-forge/hooks/factory-policy.py
+++ b/plugins/preview-forge/hooks/factory-policy.py
@@ -46,12 +46,29 @@ BLOCKED_BASH = [
      "force push to main/master blocked"),
 ]
 
-# Shell expansion bypass detection (Rule 6 reinforcement)
+# Shell expansion bypass detection (Rule 6 reinforcement).
+# Issue #64 I-2: prior implementation used BLOCKED_BASH[:4] (the first 4
+# patterns) inside $()/backtick alternations, leaving 6 destructive
+# patterns at index ≥4 (DELETE FROM, rm -rf, vercel deploy --prod,
+# gh release create, kubectl prod, git push --force) bypassable via
+# command substitution. We now alternate over the FULL list.
+_ALL_BASH_PATTERNS = "|".join(p for p, _ in BLOCKED_BASH)
 SHELL_BYPASSES = [
-    r"\$\([^)]*(?:" + "|".join([p for p, _ in BLOCKED_BASH[:4]]) + r")",
-    r"`[^`]*(?:" + "|".join([p for p, _ in BLOCKED_BASH[:4]]) + r")",
-    r"\beval\s+[\"']?\$",
+    r"\$\([^)]*(?:" + _ALL_BASH_PATTERNS + r")",
+    r"`[^`]*(?:" + _ALL_BASH_PATTERNS + r")",
+    # Any `eval` call is suspicious — eval is the canonical shell-bypass
+    # primitive for re-executing dynamically-built strings.
+    r"\beval\s+",
 ]
+
+# Issue #64 I-2 — nested-shell detection: `bash -c "<inner>"` /
+# `sh -c '<inner>'` would otherwise hide BLOCKED_BASH patterns from the
+# outer scan (the outer command is just `bash -c …` which matches no
+# rule). We extract the inner string and re-scan it.
+NESTED_SHELL_RE = re.compile(
+    r"""\b(?:bash|sh)\s+-c\s+(?P<q>["'])(?P<inner>.*?)(?P=q)""",
+    re.DOTALL,
+)
 
 # Rule 3 — memory paths only M3 can edit (but auto-retro trigger bypass is
 # allowed via a sentinel env var set by auto-retro-trigger.py).
@@ -102,6 +119,17 @@ def check_bash(command: str) -> tuple[bool, str]:
     for bypass in SHELL_BYPASSES:
         if re.search(bypass, command, re.IGNORECASE):
             return True, "Layer-0 Rule 6 — shell expansion bypass attempt detected"
+    # Issue #64 I-2: nested-shell — `bash -c "<inner>"` / `sh -c '<inner>'`.
+    # Re-scan the inner string against BLOCKED_BASH so destructive
+    # patterns can't hide one shell level down.
+    for m in NESTED_SHELL_RE.finditer(command):
+        inner = m.group("inner")
+        for pattern, reason in BLOCKED_BASH:
+            if re.search(pattern, inner, re.IGNORECASE):
+                return True, (
+                    f"Layer-0 Rule 6 — nested shell ({m.group(0)[:3].strip()} -c) "
+                    f"hides: {reason}"
+                )
     return False, ""
 
 

--- a/tests/fixtures/security/oversized-non-goals-array.json
+++ b/tests/fixtures/security/oversized-non-goals-array.json
@@ -1,0 +1,28 @@
+{
+  "_schema_version": "1.0.0",
+  "_filled_ratio": 0.5,
+  "idea_summary": "I-7 per-cap matrix: non_goals array exceeds maxItems=20.",
+  "non_goals": [
+    "goal-0",
+    "goal-1",
+    "goal-2",
+    "goal-3",
+    "goal-4",
+    "goal-5",
+    "goal-6",
+    "goal-7",
+    "goal-8",
+    "goal-9",
+    "goal-10",
+    "goal-11",
+    "goal-12",
+    "goal-13",
+    "goal-14",
+    "goal-15",
+    "goal-16",
+    "goal-17",
+    "goal-18",
+    "goal-19",
+    "goal-20"
+  ]
+}

--- a/tests/fixtures/security/oversized-non-goals-value.json
+++ b/tests/fixtures/security/oversized-non-goals-value.json
@@ -1,0 +1,8 @@
+{
+  "_schema_version": "1.0.0",
+  "_filled_ratio": 0.5,
+  "idea_summary": "I-7 per-cap matrix: non_goals item exceeds maxLength=500.",
+  "non_goals": [
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  ]
+}

--- a/tests/fixtures/security/oversized-type-field.json
+++ b/tests/fixtures/security/oversized-type-field.json
@@ -1,0 +1,11 @@
+{
+  "_schema_version": "1.0.0",
+  "_filled_ratio": 0.5,
+  "idea_summary": "I-7 per-cap matrix: must_have_constraints[0].type violates enum (oversized invalid bucket).",
+  "must_have_constraints": [
+    {
+      "type": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "value": "placeholder"
+    }
+  ]
+}

--- a/tests/fixtures/security/poisoned-previews-numeric-prefix.json
+++ b/tests/fixtures/security/poisoned-previews-numeric-prefix.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "P01",
+    "advocate": "the-contrarian",
+    "target_persona": "tester",
+    "primary_surface": "web",
+    "one_liner_pitch": "I-7 regex weakening probe — missing 'P' prefix. MOCKUP_PAT requires '^P\\d{2}-...'; '01-foo.html' has no leading P and must be rejected.",
+    "spec_alignment_notes": "Defends against MOCKUP_PAT being relaxed to '^\\d{2}-...' or anchored without the 'P' literal.",
+    "mockup_path": "01-foo.html"
+  }
+]

--- a/tests/fixtures/security/poisoned-previews-underscore.json
+++ b/tests/fixtures/security/poisoned-previews-underscore.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "P01",
+    "advocate": "the-contrarian",
+    "target_persona": "tester",
+    "primary_surface": "web",
+    "one_liner_pitch": "I-7 regex weakening probe — underscore in the slug is NOT in [a-z0-9-]; MOCKUP_PAT must reject.",
+    "spec_alignment_notes": "If MOCKUP_PAT were weakened to allow `_` (e.g. \\w which matches [A-Za-z0-9_]), this slug would slip past. We assert the strict charset stays strict.",
+    "mockup_path": "P01-a_b.html"
+  }
+]

--- a/tests/fixtures/security/poisoned-previews-uppercase.json
+++ b/tests/fixtures/security/poisoned-previews-uppercase.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "P01",
+    "advocate": "the-contrarian",
+    "target_persona": "tester",
+    "primary_surface": "web",
+    "one_liner_pitch": "I-7 regex weakening probe — uppercase letter in the slug must be rejected by MOCKUP_PAT='^P\\d{2}-[a-z0-9-]+\\.html$'.",
+    "spec_alignment_notes": "If MOCKUP_PAT were weakened to the case-insensitive [A-Za-z0-9-] charset, this fixture would slip through. The lowercase-only constraint is what stops attacker-controlled tool tags like 'P01-FOO.html' from co-existing with attacker-uploaded sibling files.",
+    "mockup_path": "P01-FOO.html"
+  }
+]

--- a/tests/fixtures/security/url-injection-matrix.json
+++ b/tests/fixtures/security/url-injection-matrix.json
@@ -1,0 +1,14 @@
+[
+  "http://example.com/path'quote",
+  "http://example.com/path`backtick",
+  "http://example.com/path\\backslash",
+  "http://example.com/path with space",
+  "http://example.com/path;semicolon",
+  "http://example.com/path<lt",
+  "http://example.com/path>gt",
+  "http://example.com/path\nnewline",
+  "http://example.com/path\rcr",
+  "http://example.com/path$dollar",
+  "http://example.com/path(paren",
+  "http://example.com/path\\\\twoslash"
+]

--- a/tests/fixtures/security/url-injection-positives.json
+++ b/tests/fixtures/security/url-injection-positives.json
@@ -1,0 +1,7 @@
+[
+  "https://example.com/path?a=1&b=2",
+  "https://example.com/search?q=foo+bar",
+  "https://example.com/~user/page",
+  "https://example.com/path?key=value",
+  "https://example.com/path%20encoded"
+]

--- a/tests/fixtures/security/verify-security.sh
+++ b/tests/fixtures/security/verify-security.sh
@@ -36,7 +36,9 @@ for fixture in poisoned-previews-traversal.json poisoned-previews-url-scheme.jso
   printf '<html><body>stub</body></html>' > "$tmp_run/mockups/P99-stub.html"
   out=$(cd "$REPO_ROOT" && bash scripts/generate-gallery.sh "$tmp_run" 2>&1 || true)
   skipped=$(printf '%s' "$out" | grep -c "skipping preview id=" || true)
-  total=$(python3 -c "import json;print(len(json.load(open('$FIXTURES_DIR/$fixture'))))")
+  total=$(python3 -c "import json,sys
+with open(sys.argv[1]) as f:
+    print(len(json.load(f)))" "$FIXTURES_DIR/$fixture")
   if [[ "$skipped" -eq "$total" ]]; then
     pass "$fixture — all $total cards rejected"
   else
@@ -50,7 +52,9 @@ done
 echo
 echo "[I-7] open-browser.sh URL gate — injection matrix"
 url_inj_fails=0
-matrix_total=$(python3 -c "import json;print(len(json.load(open('$FIXTURES_DIR/url-injection-matrix.json'))))")
+matrix_total=$(python3 -c "import json,sys
+with open(sys.argv[1]) as f:
+    print(len(json.load(f)))" "$FIXTURES_DIR/url-injection-matrix.json")
 # NUL-separated emit so URLs containing literal \n / \r (which the
 # matrix deliberately includes) survive the pipeline intact. bash 3.2
 # (still default on macOS) has no `mapfile`, so we use `while IFS= read
@@ -67,9 +71,10 @@ while IFS= read -r -d '' url; do
     url_inj_fails=$((url_inj_fails + 1))
   fi
 done < <(python3 -c "import json,sys
-for u in json.load(open('$FIXTURES_DIR/url-injection-matrix.json')):
-    sys.stdout.write(u)
-    sys.stdout.write('\x00')")
+with open(sys.argv[1]) as f:
+    for u in json.load(f):
+        sys.stdout.write(u)
+        sys.stdout.write('\x00')" "$FIXTURES_DIR/url-injection-matrix.json")
 if [[ "$url_inj_fails" -eq 0 ]]; then
   pass "url-injection-matrix.json — all $matrix_total dangerous URLs rejected (rc=1)"
 fi
@@ -77,7 +82,9 @@ fi
 echo
 echo "[I-7] open-browser.sh URL gate — positive matrix (must NOT over-narrow)"
 pos_fails=0
-pos_total=$(python3 -c "import json;print(len(json.load(open('$FIXTURES_DIR/url-injection-positives.json'))))")
+pos_total=$(python3 -c "import json,sys
+with open(sys.argv[1]) as f:
+    print(len(json.load(f)))" "$FIXTURES_DIR/url-injection-positives.json")
 # Same NUL-separated portable pattern as the negative matrix above.
 while IFS= read -r -d '' url; do
   rc=0
@@ -92,23 +99,28 @@ while IFS= read -r -d '' url; do
     pos_fails=$((pos_fails + 1))
   fi
 done < <(python3 -c "import json,sys
-for u in json.load(open('$FIXTURES_DIR/url-injection-positives.json')):
-    sys.stdout.write(u)
-    sys.stdout.write('\x00')")
+with open(sys.argv[1]) as f:
+    for u in json.load(f):
+        sys.stdout.write(u)
+        sys.stdout.write('\x00')" "$FIXTURES_DIR/url-injection-positives.json")
 if [[ "$pos_fails" -eq 0 ]]; then
   pass "url-injection-positives.json — all $pos_total benign URLs accepted (rc!=1)"
 fi
 
 echo
 echo "[I-7] idea-spec.schema.json — per-cap matrix"
-python3 - <<PYEOF || fails=$((fails + 1))
+# Pass schema path + fixtures dir as argv (gemini security-high #85):
+# avoids shell-variable interpolation into the inline Python script.
+python3 - "$REPO_ROOT/plugins/preview-forge/schemas/idea-spec.schema.json" "$FIXTURES_DIR" <<'PYEOF' || fails=$((fails + 1))
 import json, sys
 try:
     import jsonschema
 except ImportError:
     print("  x jsonschema not installed - I-7 per-cap defenses cannot be verified.", file=sys.stderr)
     sys.exit(1)
-schema = json.load(open("$REPO_ROOT/plugins/preview-forge/schemas/idea-spec.schema.json"))
+with open(sys.argv[1]) as f:
+    schema = json.load(f)
+fixtures_dir = sys.argv[2]
 
 # (fixture filename, expected JSON-pointer prefix, expected validator name)
 #   - oversized-non-goals-value : items[0] is 501 chars -> maxLength on non_goals/0
@@ -125,7 +137,8 @@ cases = [
 
 regressions = 0
 for fixture, expected_path, expected_validator in cases:
-    payload = json.load(open(f"$FIXTURES_DIR/{fixture}"))
+    with open(f"{fixtures_dir}/{fixture}") as f:
+        payload = json.load(f)
     try:
         jsonschema.validate(payload, schema)
         print(f"  x {fixture} - REGRESSION: schema accepted oversized payload", file=sys.stderr)

--- a/tests/fixtures/security/verify-security.sh
+++ b/tests/fixtures/security/verify-security.sh
@@ -25,7 +25,7 @@ echo
 
 # ----- S-1 : poisoned previews -------------------------------------------
 echo "[S-1] generate-gallery mockup_path guard"
-for fixture in poisoned-previews-traversal.json poisoned-previews-url-scheme.json; do
+for fixture in poisoned-previews-traversal.json poisoned-previews-url-scheme.json poisoned-previews-uppercase.json poisoned-previews-underscore.json poisoned-previews-numeric-prefix.json; do
   # Synthesize a minimal run-dir: <tmp>/previews.json + one dummy mockup
   # HTML so generate-gallery takes the iframe code path (otherwise it
   # falls through to the cache-hit placeholder branch that never runs
@@ -45,6 +45,106 @@ for fixture in poisoned-previews-traversal.json poisoned-previews-url-scheme.jso
   fi
   rm -rf "$tmp_run"
 done
+
+# ----- I-7 : regex weakening probes & per-cap matrix (PR W1.3, #69) -----
+echo
+echo "[I-7] open-browser.sh URL gate — injection matrix"
+url_inj_fails=0
+matrix_total=$(python3 -c "import json;print(len(json.load(open('$FIXTURES_DIR/url-injection-matrix.json'))))")
+# NUL-separated emit so URLs containing literal \n / \r (which the
+# matrix deliberately includes) survive the pipeline intact. bash 3.2
+# (still default on macOS) has no `mapfile`, so we use `while IFS= read
+# -r -d ''` which is portable back to 3.x.
+while IFS= read -r -d '' url; do
+  rc=0
+  bash "$REPO_ROOT/scripts/open-browser.sh" "$url" >/dev/null 2>&1 || rc=$?
+  # The URL gate must REJECT (exit 1). Any other rc means the gate
+  # silently widened: either it accepted the dangerous char (rc=0) or
+  # it crashed in a different code path so the regression signal is
+  # muddled. We require strict rc=1.
+  if [[ "$rc" -ne 1 ]]; then
+    fail "I-7 URL matrix accepted dangerous URL (rc=$rc): $(printf '%q' "$url")"
+    url_inj_fails=$((url_inj_fails + 1))
+  fi
+done < <(python3 -c "import json,sys
+for u in json.load(open('$FIXTURES_DIR/url-injection-matrix.json')):
+    sys.stdout.write(u)
+    sys.stdout.write('\x00')")
+if [[ "$url_inj_fails" -eq 0 ]]; then
+  pass "url-injection-matrix.json — all $matrix_total dangerous URLs rejected (rc=1)"
+fi
+
+echo
+echo "[I-7] open-browser.sh URL gate — positive matrix (must NOT over-narrow)"
+pos_fails=0
+pos_total=$(python3 -c "import json;print(len(json.load(open('$FIXTURES_DIR/url-injection-positives.json'))))")
+# Same NUL-separated portable pattern as the negative matrix above.
+while IFS= read -r -d '' url; do
+  rc=0
+  # We test the S-2 gate in isolation: the URL must NOT trigger the
+  # gate's exit-1 rejection path. rc=0 (opener succeeded) or rc=3 (no
+  # opener available — A-5 non-fatal in CI) both mean the URL passed
+  # the gate; only rc=1 indicates the over-narrowing regression we
+  # want to catch.
+  bash "$REPO_ROOT/scripts/open-browser.sh" "$url" >/dev/null 2>&1 || rc=$?
+  if [[ "$rc" -eq 1 ]]; then
+    fail "I-7 URL positives over-narrowed and rejected: $(printf '%q' "$url")"
+    pos_fails=$((pos_fails + 1))
+  fi
+done < <(python3 -c "import json,sys
+for u in json.load(open('$FIXTURES_DIR/url-injection-positives.json')):
+    sys.stdout.write(u)
+    sys.stdout.write('\x00')")
+if [[ "$pos_fails" -eq 0 ]]; then
+  pass "url-injection-positives.json — all $pos_total benign URLs accepted (rc!=1)"
+fi
+
+echo
+echo "[I-7] idea-spec.schema.json — per-cap matrix"
+python3 - <<PYEOF || fails=$((fails + 1))
+import json, sys
+try:
+    import jsonschema
+except ImportError:
+    print("  x jsonschema not installed - I-7 per-cap defenses cannot be verified.", file=sys.stderr)
+    sys.exit(1)
+schema = json.load(open("$REPO_ROOT/plugins/preview-forge/schemas/idea-spec.schema.json"))
+
+# (fixture filename, expected JSON-pointer prefix, expected validator name)
+#   - oversized-non-goals-value : items[0] is 501 chars -> maxLength on non_goals/0
+#   - oversized-non-goals-array : 21 items -> maxItems on non_goals
+#   - oversized-type-field      : type='X'*60 -> enum on must_have_constraints/0/type
+#     (the schema enforces enum, not maxLength, on `type`; the cap that
+#     REJECTS oversized type strings IS the enum, so that's the right
+#     field+validator pair to assert.)
+cases = [
+    ("oversized-non-goals-value.json",  ["non_goals", 0],                         "maxLength"),
+    ("oversized-non-goals-array.json",  ["non_goals"],                            "maxItems"),
+    ("oversized-type-field.json",       ["must_have_constraints", 0, "type"],     "enum"),
+]
+
+regressions = 0
+for fixture, expected_path, expected_validator in cases:
+    payload = json.load(open(f"$FIXTURES_DIR/{fixture}"))
+    try:
+        jsonschema.validate(payload, schema)
+        print(f"  x {fixture} - REGRESSION: schema accepted oversized payload", file=sys.stderr)
+        regressions += 1
+        continue
+    except jsonschema.ValidationError as e:
+        actual_path = list(e.absolute_path)
+        actual_validator = e.validator
+        if actual_path[:len(expected_path)] == expected_path and actual_validator == expected_validator:
+            print(f"  ok {fixture} - rejected ({actual_validator} on {actual_path})")
+        else:
+            print(f"  x {fixture} - rejected on WRONG cap: got "
+                  f"validator={actual_validator} path={actual_path}, "
+                  f"expected validator={expected_validator} path={expected_path}", file=sys.stderr)
+            regressions += 1
+
+if regressions:
+    sys.exit(1)
+PYEOF
 
 # ----- T-4 : generate-gallery XSS escape (Phase 3 Test & CI) ----------
 echo
@@ -149,7 +249,14 @@ printf '<!doctype html><html><body>stub</body></html>' > "$target_html"
 # Strip macOS-provided `open` and any real `xdg-open` so the fake is
 # first. `command -v open` must fail for the test to exercise the
 # xdg-open branch.
-t6_path="$tmp_t6/fake-bin:/usr/bin:/bin"
+t6_path="$tmp_t6/fake-bin:/bin"   # I-7 fix: drop /usr/bin (was
+                                    # "$tmp_t6/fake-bin:/usr/bin:/bin") so the
+                                    # macOS-provided /usr/bin/open is no longer
+                                    # reachable and the fake xdg-open shim
+                                    # actually wins. /bin is kept so bash / sh
+                                    # / cat / etc. still resolve. Without this
+                                    # fix the T-6 shim assertion dead-skipped
+                                    # on Darwin.
 t6_log="$tmp_t6/xdg-open.log"
 rc=0
 PATH="$t6_path" XDG_OPEN_LOG="$t6_log" \


### PR DESCRIPTION
## Summary

Closes #64 (I-2: factory-policy SHELL_BYPASSES coverage gap) and #69
(I-7: regex weakening probes).

- **`factory-policy.py` SHELL_BYPASSES**: previously alternated only over
  `BLOCKED_BASH[:4]`, leaving 6 destructive patterns at index ≥4 (SQL
  delete-without-WHERE, wide rm, prod deploy, release publish, kubectl
  prod ops, force push to main) bypassable via `$(…)` and backtick
  substitution. Now alternates over the **full** BLOCKED_BASH list.
  Also tightens the eval bypass and adds nested-shell detection for
  `(bash|sh) -c "<inner>"` so destructive patterns can't hide one
  shell level down.

- **Regex/cap weakening probes** under `tests/fixtures/security/`:
  3 MOCKUP_PAT probes (uppercase, underscore, missing-`P`-prefix),
  a 12-URL injection matrix (each with one dangerous char) + a 5-URL
  positive matrix that asserts `&`, `+`, `~`, `=`, `%20` stay accepted,
  and a 3-fixture per-cap matrix for `idea-spec.schema.json` that
  asserts rejection on the **exact** field+validator pair. Wired into
  the existing `verify-security.sh` fixture loop.

- **macOS T-6 shim path fix**: `t6_path` was
  `"$tmp_t6/fake-bin:/usr/bin:/bin"`, which let macOS-provided
  `/usr/bin/open` win and dead-skipped the shim assertion on Darwin.
  Now `"$tmp_t6/fake-bin:/bin"` — `/bin` keeps `bash`/`sh`/`cat`
  resolvable but no `/usr/bin/open`, so the xdg-open shim branch
  actually runs.

## Test plan

- [x] `python3 -m py_compile plugins/preview-forge/hooks/factory-policy.py`
- [x] `bash tests/fixtures/security/verify-security.sh` — all 16
  assertions green (S-1 ×5, I-7 URL matrix, I-7 URL positives, I-7
  per-cap ×3, T-4, S-3, T-6 shim + S-2 gate, T-9.x, S-5, S-6).
- [x] Local probe of factory-policy I-2 fixes (12 cases including
  `eval $(echo rm -rf /tmp/x)`, `bash -c "rm -rf /tmp/x"`,
  `sh -c 'DROP TABLE'`, `$(DELETE FROM …)`, backtick `gh release
  create`, command-sub `kubectl … prod`, `git push --force … main`):
  all expected exit codes match.
- [x] T-6 shim assertion now passes on macOS (xdg-open receives
  `file://…` URL as expected) instead of dead-skipping.

## Codex review summary

Ran `codex review --base origin/main` once.

- **P1 findings: 0** — nothing to apply.
- **P2 (out of scope, not fixed in this PR)**: Narrow the new `eval`
  bypass regex — `\beval\s+` matches any literal `eval ` substring
  even inside quoted data, so commands like
  `grep -n "eval " factory-policy.py` are now blocked. Acceptable as a
  conservative default for a security hook, but a follow-up should
  refine it (e.g. require start-of-token or a non-quoted context).
- **P3 (out of scope, not fixed in this PR)**: Stub the opener in the
  positive URL matrix — `verify-security.sh` runs the real
  `open-browser.sh` for the 5 benign URLs. On a workstation with a
  GUI opener this opens 5 browser tabs (CI is headless, so noop
  there). A follow-up should add a `BROWSER`/`PATH` shim around the
  positive loop the same way T-6 does for the negative shim test.

`Closes #64`
`Closes #69`
