### PR TITLE
refactor(advocates): re-sync boilerplate + lint guard (#61)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,6 +483,11 @@ jobs:
           fi
           echo "✓ 26/26 advocates reference idea.spec.json"
 
+      - name: All 26 advocates share boilerplate (W2.6 / #61)
+        # Guards against silent boilerplate drift across the 26 P*.md
+        # advocate files — future schema-wide edits MUST hit every file.
+        run: bash tests/test-advocate-boilerplate.sh
+
       - name: Check all agents use Opus 4.7
         run: |
           python3 <<'PYEOF'

--- a/tests/test-advocate-boilerplate.sh
+++ b/tests/test-advocate-boilerplate.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# tests/test-advocate-boilerplate.sh
+#
+# Asserts that all 26 Tier-3 advocate agent files share a single
+# normalized boilerplate hash after stripping personalized regions.
+#
+# Why: at v1.6.0 the 26 P*.md files were byte-identical except for a small
+# set of per-persona fields (name, description, voice, JSON id/advocate/
+# primary_surface, mockup path/style, cross-mention, allowed_scope path).
+# Patches v1.6.1..v1.11.0 risked silent drift across the boilerplate
+# (instructions, mockup spec, idea_spec_alignment_notes section, Diversity
+# validator hint, etc.). Future schema-wide edits MUST hit all 26 files
+# uniformly. This lint enforces that invariant.
+#
+# Marker scheme: regex-based personalized-line stripping (no in-file
+# markers were added — current files have zero structural drift, so
+# marker injection would be 26 noisy diffs for no benefit). The list of
+# stripped patterns is exhaustive for the current advocate template; if
+# the template grows a NEW personalized field, this lint must be updated
+# together with the template change (intentional friction — that PR is
+# also the PR that should re-sync the boilerplate).
+#
+# Usage:   bash tests/test-advocate-boilerplate.sh
+# CI hook: invoked from .github/workflows/ci.yml under agent-counts job.
+#
+# Exit codes:
+#   0  PASS — all 26 files normalize to a single hash
+#   1  FAIL — drift detected (per-file hashes printed for diagnosis)
+#   2  FAIL — wrong number of advocate files (expected 26)
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ADVOCATES_DIR="$ROOT/plugins/preview-forge/agents/ideation/advocates"
+
+if [[ ! -d "$ADVOCATES_DIR" ]]; then
+  echo "FAIL: advocates dir not found: $ADVOCATES_DIR" >&2
+  exit 2
+fi
+
+# Collect advocate files (P01..P26).
+# Avoid `mapfile` for bash 3.2 compatibility (macOS system bash).
+FILES=()
+while IFS= read -r line; do
+  FILES+=("$line")
+done < <(find "$ADVOCATES_DIR" -maxdepth 1 -name 'P*.md' -type f | sort)
+if [[ "${#FILES[@]}" -ne 26 ]]; then
+  echo "FAIL: expected 26 advocate files, found ${#FILES[@]}" >&2
+  exit 2
+fi
+
+# normalize <file>: emit a stripped/canonicalized stream to stdout
+# Stripped/replaced (these are the personalized regions per advocate):
+#   - frontmatter `name:` line             (per-persona slug)
+#   - frontmatter `description:` line      (per-persona blurb)
+#   - frontmatter `bias:` line if present  (forward-compat)
+#   - H1 header `# P\d\d — ...`            (per-persona title)
+#   - `**핵심 편향**:` line                 (per-persona bias)
+#   - `**voice**:` line                    (per-persona voice)
+#   - JSON `"id": "P\d+"`                  (per-persona id)
+#   - JSON `"advocate": "..."`             (per-persona name)
+#   - JSON `"primary_surface": "..."`      (per-persona surface)
+#   - mockup path `runs/<id>/mockups/P\d+-the-...html`
+#   - mockup style line `**이 페르소나의 mockup 스타일**:`
+#   - cross-mention line containing `the-<slug>이 아닌` / `가 아닌`
+#   - allowed_scope `Write:` line referring to per-persona mockup
+#
+# Implementation: portable POSIX awk + sed — works on macOS BSD and
+# Linux GNU userland (T-12 macOS-CI parity).
+normalize() {
+  awk '
+    # Drop personalized lines outright.
+    /^name:[[:space:]]/                      { next }
+    /^description:[[:space:]]/               { next }
+    /^bias:[[:space:]]/                      { next }
+    /^# P[0-9]+ —/                           { print "# PXX — <PERSONA> (Tier 3 · Preview Advocate)"; next }
+    /^\*\*핵심 편향\*\*:/                     { next }
+    /^\*\*voice\*\*:/                        { next }
+    /^\*\*이 페르소나의 mockup 스타일\*\*:/   { next }
+    # Replace JSON id/advocate/primary_surface values with placeholders.
+    /^[[:space:]]*"id":[[:space:]]*"P[0-9]+"/ { print "  \"id\": \"PXX\","; next }
+    /^[[:space:]]*"advocate":[[:space:]]*"/   { print "  \"advocate\": \"<PERSONA>\","; next }
+    /^[[:space:]]*"primary_surface":[[:space:]]*"/ { print "  \"primary_surface\": \"<SURFACE>\","; next }
+    # Replace mockup path occurrences.
+    /runs\/<id>\/mockups\/P[0-9]+-the-[a-z0-9-]+\.html/ {
+      gsub(/P[0-9]+-the-[a-z0-9-]+\.html/, "PXX-the-X.html")
+    }
+    # Replace cross-mention slug references.
+    /the-[a-z0-9-]+(이|가) 아닌/ {
+      gsub(/the-[a-z0-9-]+(이|가) 아닌/, "the-X<P> 아닌")
+    }
+    { print }
+  ' "$1"
+}
+
+declare -a HASHES=()
+for f in "${FILES[@]}"; do
+  h=$(normalize "$f" | shasum -a 256 | awk '{print $1}')
+  HASHES+=("$h  $(basename "$f")")
+done
+
+distinct=$(printf '%s\n' "${HASHES[@]}" | awk '{print $1}' | sort -u | wc -l | tr -d ' ')
+if [[ "$distinct" -ne 1 ]]; then
+  echo "FAIL: 26 advocate files normalize to $distinct distinct hashes (expected 1 — boilerplate drift detected)" >&2
+  echo "" >&2
+  echo "per-file normalized hashes:" >&2
+  printf '  %s\n' "${HASHES[@]}" | sort >&2
+  echo "" >&2
+  echo "Hint: run \`diff <(bash tests/test-advocate-boilerplate.sh; cd $ADVOCATES_DIR && for f in P*.md; do echo === \$f ===; done)\` and inspect divergent files." >&2
+  exit 1
+fi
+
+echo "PASS: 26 advocate files share a single normalized boilerplate hash (${HASHES[0]%% *})"

--- a/tests/test-advocate-boilerplate.sh
+++ b/tests/test-advocate-boilerplate.sh
@@ -20,13 +20,20 @@
 # together with the template change (intentional friction — that PR is
 # also the PR that should re-sync the boilerplate).
 #
-# Usage:   bash tests/test-advocate-boilerplate.sh
+# Usage:
+#   bash tests/test-advocate-boilerplate.sh                # full lint
+#   bash tests/test-advocate-boilerplate.sh --normalize FILE
+#                                                          # emit the
+#     normalized stream for one advocate file to stdout (debug helper —
+#     pair two invocations through `diff` to locate the drifting line).
+#
 # CI hook: invoked from .github/workflows/ci.yml under agent-counts job.
 #
 # Exit codes:
 #   0  PASS — all 26 files normalize to a single hash
 #   1  FAIL — drift detected (per-file hashes printed for diagnosis)
 #   2  FAIL — wrong number of advocate files (expected 26)
+#      (also returned for --normalize argument errors)
 
 set -euo pipefail
 
@@ -35,17 +42,6 @@ ADVOCATES_DIR="$ROOT/plugins/preview-forge/agents/ideation/advocates"
 
 if [[ ! -d "$ADVOCATES_DIR" ]]; then
   echo "FAIL: advocates dir not found: $ADVOCATES_DIR" >&2
-  exit 2
-fi
-
-# Collect advocate files (P01..P26).
-# Avoid `mapfile` for bash 3.2 compatibility (macOS system bash).
-FILES=()
-while IFS= read -r line; do
-  FILES+=("$line")
-done < <(find "$ADVOCATES_DIR" -maxdepth 1 -name 'P*.md' -type f | sort)
-if [[ "${#FILES[@]}" -ne 26 ]]; then
-  echo "FAIL: expected 26 advocate files, found ${#FILES[@]}" >&2
   exit 2
 fi
 
@@ -93,6 +89,32 @@ normalize() {
   ' "$1"
 }
 
+# Debug mode: `--normalize FILE` prints the normalized stream for a single
+# advocate file. Pair two invocations through `diff` to pinpoint the
+# specific line(s) that diverge:
+#
+#   diff <(bash tests/test-advocate-boilerplate.sh --normalize FILE_A) \
+#        <(bash tests/test-advocate-boilerplate.sh --normalize FILE_B)
+if [[ "${1:-}" == "--normalize" ]]; then
+  if [[ -z "${2:-}" || ! -f "$2" ]]; then
+    echo "FAIL: --normalize requires a path to an existing advocate file" >&2
+    exit 2
+  fi
+  normalize "$2"
+  exit 0
+fi
+
+# Collect advocate files (P01..P26).
+# Avoid `mapfile` for bash 3.2 compatibility (macOS system bash).
+FILES=()
+while IFS= read -r line; do
+  FILES+=("$line")
+done < <(find "$ADVOCATES_DIR" -maxdepth 1 -name 'P*.md' -type f | sort)
+if [[ "${#FILES[@]}" -ne 26 ]]; then
+  echo "FAIL: expected 26 advocate files, found ${#FILES[@]}" >&2
+  exit 2
+fi
+
 declare -a HASHES=()
 for f in "${FILES[@]}"; do
   h=$(normalize "$f" | shasum -a 256 | awk '{print $1}')
@@ -106,7 +128,15 @@ if [[ "$distinct" -ne 1 ]]; then
   echo "per-file normalized hashes:" >&2
   printf '  %s\n' "${HASHES[@]}" | sort >&2
   echo "" >&2
-  echo "Hint: run \`diff <(bash tests/test-advocate-boilerplate.sh; cd $ADVOCATES_DIR && for f in P*.md; do echo === \$f ===; done)\` and inspect divergent files." >&2
+  echo "Hint: identify two files with different hashes above, then diff" >&2
+  echo "      their normalized streams to see the exact drifting line(s):" >&2
+  echo "" >&2
+  echo "  diff \\" >&2
+  echo "    <(bash tests/test-advocate-boilerplate.sh --normalize <FILE_A>) \\" >&2
+  echo "    <(bash tests/test-advocate-boilerplate.sh --normalize <FILE_B>)" >&2
+  echo "" >&2
+  echo "  (replace <FILE_A> / <FILE_B> with two paths from $ADVOCATES_DIR" >&2
+  echo "   whose hashes diverge in the table above.)" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

W2.6 — Tier-3 advocate boilerplate re-sync + lint guard. Closes #61.

T-team review (#61) flagged the 26 `P*.md` advocate files as the single biggest v1.12 landmine: at v1.6.0 they were byte-identical except for a small per-persona region, but patches v1.6.1..v1.11.0 risked silent drift across the shared boilerplate (instructions, mockup spec, idea_spec_alignment_notes section, Diversity-validator hint, etc.). Future schema-wide edits would have silently missed files.

## Diagnosis

Hashing all 26 advocates after stripping the 12 known personalized line patterns yields **a single distinct hash** — there is **no structural drift today**. The risk is purely forward-looking. Therefore this PR ships **no advocate file content changes** and instead lands the prevention infrastructure (lint + CI guard).

## Marker scheme

**Regex-based personalized-line stripping in the lint** — no in-file `<!-- PERSONALIZED -->` markers added.

Rationale:
- Current files have zero drift → injecting markers across all 26 files would be 26 noisy diffs for no immediate benefit.
- The lint encodes the personalized-region surface as an explicit allowlist of patterns; extending the advocate template's personalized surface in a future PR MUST update this lint in the same PR (intentional friction — that PR is also the one that should re-sync boilerplate).
- Portable POSIX awk + sed: works on both macOS BSD and Linux GNU userland (T-12 macOS-CI parity).
- Bash-3.2 compatible (no `mapfile`) — works on macOS system bash.

Patterns stripped/replaced (per file): `name:` / `description:` / `bias:` frontmatter lines; H1 header; `**핵심 편향**:` / `**voice**:` lines; JSON `id` / `advocate` / `primary_surface` values; mockup path; `**이 페르소나의 mockup 스타일**:` line; cross-mention `the-<slug>(이|가) 아닌` clause.

## Diff summary

- **0 advocate files modified** (no drift to fix)
- **2 files changed, 118 insertions(+):**
  - `tests/test-advocate-boilerplate.sh` (NEW, 109 LOC) — sha256 invariant lint
  - `.github/workflows/ci.yml` (+5 LOC) — wires lint into the existing `agent-counts` job

## Test plan

- [x] `bash tests/test-advocate-boilerplate.sh` → PASS (single normalized hash `b9246978…`)
- [x] `bash scripts/verify-plugin.sh` → 57/57 pass
- [x] **Mutation test**: `sed -i 's/idea.spec.json/idea_spec_json/' P05*.md` → lint exits 1 with divergent hash printed. Restored.
- [x] **False-positive guard**: mutating personalized `UX first` in P05 description → lint still PASSes (correctly ignored).
- [ ] CI: ubuntu-latest + macos-14 matrix runs the lint.

## Codex review (1 pass)

- **P1: 0**
- **P2: 1** — _Preserve shared boilerplate in mixed description/header lines_ (`tests/test-advocate-boilerplate.sh:74-76`). Codex notes that `normalize()` drops/rewrites whole lines for `description:` and `# P\d\d — …` instead of masking only the personalized tokens; if the shared suffix `PreviewDD cycle…` or the role tag `(Tier 3 · Preview Advocate)` drifts in one file, this lint would not catch it. **Deferred** — addressing this requires either token-level masking (fragile across Korean punctuation) or a richer marker scheme. The current lint catches every full-line drift in the rest of the file, which covers the dominant risk. Tracked for a follow-up if drift is observed in those mixed lines.
- **P3: 1** — _Emit a usable diff hint for drift failures_ (`tests/test-advocate-boilerplate.sh:109`). The error-path "hint" subshell is not directly runnable. **Deferred** — when the lint fails it already prints per-file hashes, which is sufficient to identify divergent files; the hint is sugar. Will polish if drift ever fires in practice.

## Out of scope (boundaries)

- `agents/ideation/ideation-lead.md` (W2.7)
- `agents/ideation/diversity-validator.md` (W2.8)
- `agents/meta/chief-engineer-pm.md` (W2.7 + W2.8 share)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)