### PR TITLE
feat(ideation,meta): A-6 framework lint + C-5 spec-anchor audit (#59 #62)

### DIFF
--- a/plugins/preview-forge/agents/ideation/diversity-validator.md
+++ b/plugins/preview-forge/agents/ideation/diversity-validator.md
@@ -31,13 +31,41 @@ model: opus
 - 26 advocate의 `one_liner_pitch` 텍스트를 MinHash LSH로 비교
 - 2개 이상 cluster 형성 시 경고 (페르소나가 서로 중복됨을 의미)
 
-### 4. Framework convergence lint (v1.7.0+ A-6)
-- 목적: 같은 `primary_surface` 값(예: `"Web PWA"`)을 26 advocate가 **완전히 다른 framework**로 해석해서 내부 분산만 크고 사용자에게는 혼돈만 주는 실패 모드 차단.
-- 입력: 각 card의 `spec_alignment_notes`(v1.6.0+ 필드, v1.7.0부터 schema `required`).
-- 추출: `spec_alignment_notes` 텍스트에서 framework 토큰을 정규식/키워드 사전으로 추출 — 최소 대상 세트: `React`, `Vue`, `Svelte`, `SolidJS`, `Next.js`, `Nuxt`, `SvelteKit`, `Astro`, `Remix`, `SPA`, `SSR`, `SSG`, `static`, `htmx`, `Phoenix LiveView`. 대소문자 무시, 단어 경계(`\b`) 매치.
-- 집계: `primary_surface` 값별로 선택된 framework 집합을 구함.
-- Lint rule: 어느 surface든 **distinct framework ≥ 4** 이면 해당 surface를 선택한 advocate 전원을 `retry_requests`에 추가(+ reason: `"framework_convergence surface=<X> chosen={<A>,<B>,<C>,<D>} ≥ 4"`). I_LEAD는 재작성 프롬프트에 "같은 surface를 고른 이웃 advocate가 선택한 framework 목록"을 전달해 수렴 유도.
-- 예외: `spec_alignment_notes`에 framework 토큰이 하나도 없으면 해당 card는 집계에서 제외(구체적 언급이 없으므로 중복 유발 아님).
+<!-- A-6 lint section (W2.8, issue #59) -->
+### 4. Framework convergence lint (v1.7.0+ A-6, issue #59)
+
+**Canonical implementation**: `scripts/lint-framework-convergence.py`
+(regex source-of-truth: `scripts/_advocate_parsing.py` ·
+`FRAMEWORK_TOKENS`).
+
+- 목적: 26 advocate가 같은 `primary_surface`를 **완전히 다른 framework**로
+  해석해 내부 분산만 크고 사용자에겐 혼돈만 주는 실패 모드 차단.
+- 입력: 각 card의 `spec_alignment_notes` (v1.6.0+ 필드, v1.7.0부터 schema
+  `required`). 디렉터리 단위로 `P*.json` 26개를 일괄 처리.
+- 추출: 위 helper의 정규식/키워드 사전으로 framework 토큰 추출 — 대상
+  세트: react · vue · svelte · solidjs · nextjs · nuxt · sveltekit · astro
+  · remix · spa · ssr · ssg · static · htmx · hotwire · phoenix-liveview ·
+  native. 대소문자 무시, 단어 경계(`\b`) 매치, 더 구체적인 토큰 우선
+  (`sveltekit` ⟶ `svelte`).
+- Lint rule: distinct (named) framework count > **convergence_threshold**
+  (default 3, `-t/--threshold` overridable) 이면 warning. 가장 인기 없는
+  버킷의 advocate들이 `diverged_advocates`로 집계되어 `retry_requests`에
+  들어간다.
+- 호출 (I_LEAD dispatcher pseudo-code):
+  ```bash
+  python3 "${CLAUDE_PLUGIN_ROOT}/../../scripts/lint-framework-convergence.py" \
+      runs/<id>/ -t 3 > runs/<id>/framework-convergence.json
+  RC=$?
+  # RC=0 → converged · RC=2 → warning, parse diverged_advocates
+  # RC=1 → fixture / IO error → escalate to I_LEAD
+  ```
+- 예외: framework 토큰이 하나도 없는 card는 `unknown` 버킷으로 들어가며
+  `distinct_count` 계산에서 제외 (구체적 언급이 없으므로 중복 유발 아님).
+- Fixture verification: `tests/fixtures/spec-anchor-convergence/verify.sh`
+  (case-aligned / case-divergent / case-low-confidence). Mutation regression:
+  threshold 변경 시 case-divergent에서 정확히 P24..P26 추출 어설션.
+<!-- end A-6 -->
+
 
 ## 출력
 

--- a/plugins/preview-forge/agents/meta/chief-engineer-pm.md
+++ b/plugins/preview-forge/agents/meta/chief-engineer-pm.md
@@ -161,3 +161,46 @@ Auto-retro-trigger 훅이 Blackboard에 `retro.requested` 행을 기록하면:
 - Auto-retro trigger 이벤트 수신 시
 - Gate H1/H2 AskUserQuestion 수집 시
 - 각 department lead로부터 escalation 수신 시
+
+<!-- C-5 audit section (W2.8, issue #62) -->
+## Spec-anchor audit (C-5, issue #62)
+
+After I2 Diversity Validator approves the 26 advocate outputs, M3 MUST
+invoke the audit generator to produce empirical evidence for the v1.6
+"advocates CONVERGE on idea.spec.json ground truth" headline. Without this
+artifact, the convergence claim is unmeasured marketing.
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/../../scripts/generate-spec-anchor-audit.py" \
+    runs/<id>/ runs/<id>/idea.spec.json \
+    --run-id "<id>" \
+    -o runs/<id>/spec-anchor-audit.json
+```
+
+The audit (schema: `plugins/preview-forge/schemas/spec-anchor-audit.schema.json`)
+includes:
+
+- `spec_filled_ratio` mirroring `idea.spec.json._filled_ratio`
+- `low_confidence: true` when `_filled_ratio < 0.2` (B-3 "Skip interview" path)
+- `advocate_alignments[]` with per-advocate `framework_choice`,
+  `matches_spec_persona`, `matches_spec_surface`
+- `convergence_metrics`: `framework_jaccard` (max-bucket-share),
+  `persona_distinct_count`, `surface_distinct_count`, `diverged_advocates`,
+  `convergence_threshold`
+
+The framework token extraction regex is shared with the A-6 lint via
+`scripts/_advocate_parsing.py` so both produce identical `framework_choice`
+labels.
+
+**Failure modes that MUST block freeze**:
+
+- Schema-invalid audit output (validator returns non-zero)
+- Missing or malformed `idea.spec.json`
+- Missing `P*.json` advocate cards (count < 26)
+
+Surface highlights in the Gate H1 modal: when `low_confidence: true`, prefix
+the AskUserQuestion description with a "spec consistency: <ratio>%" caveat
+so users know the anchor was thin. When `convergence_metrics.diverged_advocates`
+is non-empty, list those P-ids alongside the alternative options so users
+can spot outliers.
+<!-- end C-5 -->

--- a/plugins/preview-forge/schemas/spec-anchor-audit.schema.json
+++ b/plugins/preview-forge/schemas/spec-anchor-audit.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/Two-Weeks-Team/PreviewForgeForClaudeCode/schemas/spec-anchor-audit.schema.json",
+  "title": "SpecAnchorAudit",
+  "description": "(v1.7.0+ C-5 / issue #62) Runtime evidence artifact for the v1.6 'advocates CONVERGE on idea.spec.json' marketing claim. Generated post Diversity-Validator by `scripts/generate-spec-anchor-audit.py` from the 26 advocate output cards + the I1 idea.spec.json. Persisted at `runs/<id>/spec-anchor-audit.json`. The audit makes convergence empirically measurable: framework_jaccard for primary surface stack, persona_distinct_count, surface_distinct_count, and the list of diverged advocates that breached the framework_convergence_threshold (default 3).",
+  "type": "object",
+  "required": [
+    "run_id",
+    "spec_filled_ratio",
+    "advocate_alignments",
+    "convergence_metrics"
+  ],
+  "properties": {
+    "run_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the run this audit covers (matches runs/<run_id>/)."
+    },
+    "spec_filled_ratio": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Mirror of idea.spec.json `_filled_ratio` at audit time. <0.2 triggers `low_confidence: true`."
+    },
+    "low_confidence": {
+      "type": "boolean",
+      "description": "Convenience flag set when spec_filled_ratio < 0.2. Downstream gates (M3 Gate H1) MAY surface this as a 'spec consistency' caveat in the modal."
+    },
+    "advocate_alignments": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Per-advocate alignment record extracted from preview-card output.",
+      "items": {
+        "type": "object",
+        "required": [
+          "advocate_id",
+          "spec_field_interpretations",
+          "framework_choice",
+          "matches_spec_persona",
+          "matches_spec_surface"
+        ],
+        "properties": {
+          "advocate_id": {
+            "type": "string",
+            "pattern": "^P[0-9]{2}$"
+          },
+          "spec_field_interpretations": {
+            "type": "string",
+            "description": "Verbatim copy of the advocate's `spec_alignment_notes`."
+          },
+          "framework_choice": {
+            "type": ["string", "null"],
+            "description": "Framework token extracted via the canonical regex (see scripts/_advocate_parsing.py FRAMEWORK_TOKENS). null when no token matched."
+          },
+          "matches_spec_persona": {
+            "type": "boolean",
+            "description": "Whether advocate.target_persona substring-matches idea.spec.json target_persona.profile (case-insensitive). False if spec persona is null/unknown."
+          },
+          "matches_spec_surface": {
+            "type": "boolean",
+            "description": "Whether advocate.primary_surface aligns with idea.spec.json primary_surface.platform via the canonical surface→platform map. False if spec platform is null/unknown."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "convergence_metrics": {
+      "type": "object",
+      "required": [
+        "framework_jaccard",
+        "persona_distinct_count",
+        "surface_distinct_count",
+        "diverged_advocates"
+      ],
+      "properties": {
+        "framework_jaccard": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Convergence score for framework_choice. Defined as max-bucket-share: (count of most-popular framework) / (count of advocates with non-null framework). 1.0 means total convergence, 1/N is full divergence. Advocates with null framework are excluded from the denominator."
+        },
+        "persona_distinct_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct target_persona strings across all 26 advocate cards (case-insensitive, trimmed)."
+        },
+        "surface_distinct_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct primary_surface enum values across all 26 advocate cards."
+        },
+        "diverged_advocates": {
+          "type": "array",
+          "description": "Advocate ids whose framework_choice falls outside the top (convergence_threshold) buckets. Empty when distinct_framework_count <= convergence_threshold.",
+          "items": {
+            "type": "string",
+            "pattern": "^P[0-9]{2}$"
+          }
+        },
+        "convergence_threshold": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum allowed distinct framework count before advocates beyond the top buckets are flagged. Defaults to 3."
+        }
+      },
+      "additionalProperties": false
+    },
+    "_schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/_advocate_parsing.py
+++ b/scripts/_advocate_parsing.py
@@ -22,8 +22,8 @@ from typing import Iterable
 # plugins/preview-forge/agents/ideation/diversity-validator.md §4.
 FRAMEWORK_TOKENS: list[tuple[str, str]] = [
     ("sveltekit", r"\bsveltekit\b"),
-    ("nextjs", r"\bnext(?:\.js|js)?\b"),
-    ("nuxt", r"\bnuxt(?:\.js|js)?\b"),
+    ("nextjs", r"\bnext(?:\.js|js)\b"),
+    ("nuxt", r"\bnuxt(?:\.js|js)\b"),
     ("remix", r"\bremix\b"),
     ("astro", r"\bastro\b"),
     ("solidjs", r"\bsolid(?:js)?\b"),
@@ -87,9 +87,16 @@ def load_advocate_cards(
     cards: list[dict] = []
     for fp in sorted(base.glob("P*.json")):
         try:
-            cards.append(json.loads(fp.read_text(encoding="utf-8")))
+            with fp.open("r", encoding="utf-8") as f:
+                card = json.load(f)
         except json.JSONDecodeError as e:
             raise ValueError(f"{fp}: invalid JSON ({e})") from e
+        if not isinstance(card, dict) or "id" not in card:
+            raise ValueError(
+                f"{fp}: preview-card missing required 'id' field "
+                "(C-5 contract: malformed advocate card blocks freeze)"
+            )
+        cards.append(card)
     if expected_count is not None and len(cards) != expected_count:
         raise ValueError(
             f"advocate card count {len(cards)} != expected {expected_count} "

--- a/scripts/_advocate_parsing.py
+++ b/scripts/_advocate_parsing.py
@@ -1,0 +1,112 @@
+"""Shared helpers for parsing 26 advocate preview-card outputs.
+
+Used by:
+  - scripts/lint-framework-convergence.py (A-6, issue #59 sub-task)
+  - scripts/generate-spec-anchor-audit.py (C-5, issue #62)
+
+Canonical regex source-of-truth for framework token extraction lives here so
+both scripts agree on what counts as "react" vs "next.js" vs "unknown".
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Iterable
+
+# Canonical framework token map. Order matters: longer / more specific tokens
+# first, so e.g. "next.js" wins over "next" when both could match.
+# Each entry: (canonical_label, regex_pattern). `\b` word-boundary on both
+# sides; case-insensitive. Documented in
+# plugins/preview-forge/agents/ideation/diversity-validator.md §4.
+FRAMEWORK_TOKENS: list[tuple[str, str]] = [
+    ("sveltekit", r"\bsveltekit\b"),
+    ("nextjs", r"\bnext(?:\.js|js)?\b"),
+    ("nuxt", r"\bnuxt(?:\.js|js)?\b"),
+    ("remix", r"\bremix\b"),
+    ("astro", r"\bastro\b"),
+    ("solidjs", r"\bsolid(?:js)?\b"),
+    ("phoenix-liveview", r"\bphoenix\s+liveview\b"),
+    ("hotwire", r"\bhotwire\b"),
+    ("htmx", r"\bhtmx\b"),
+    ("react", r"\breact\b"),
+    ("vue", r"\bvue(?:\.js|js)?\b"),
+    ("svelte", r"\bsvelte\b"),
+    ("native", r"\b(?:ios\s+native|android\s+native|native\s+app)\b"),
+    ("ssr", r"\bssr\b"),
+    ("ssg", r"\bssg\b"),
+    ("spa", r"\bspa\b"),
+    ("static", r"\bstatic(?:\s+site)?\b"),
+]
+
+_COMPILED: list[tuple[str, re.Pattern[str]]] = [
+    (label, re.compile(pat, re.IGNORECASE)) for label, pat in FRAMEWORK_TOKENS
+]
+
+
+def extract_framework(text: str | None) -> str | None:
+    """Return the canonical framework label found in ``text``, else None.
+
+    Matching follows the order in :data:`FRAMEWORK_TOKENS`. The first label
+    whose regex matches wins, which is why specific tokens (`sveltekit`,
+    `nextjs`) appear before their substring siblings (`svelte`, `react`).
+    """
+    if not text:
+        return None
+    for label, rx in _COMPILED:
+        if rx.search(text):
+            return label
+    return None
+
+
+EXPECTED_ADVOCATE_COUNT = 26
+
+
+def load_advocate_cards(
+    directory: str | Path,
+    *,
+    expected_count: int | None = EXPECTED_ADVOCATE_COUNT,
+) -> list[dict]:
+    """Load every ``P*.json`` preview-card under ``directory``.
+
+    Each file is expected to contain a single JSON object that conforms to
+    `schemas/preview-card.schema.json` (id, advocate, framing, target_persona,
+    primary_surface, opus_4_7_capability, mvp_scope, one_liner_pitch,
+    mockup_path, spec_alignment_notes). Returns the list sorted by ``id``.
+
+    If ``expected_count`` is not None and the on-disk count differs, a
+    :class:`ValueError` is raised — this is the C-5 / A-6 contract surface:
+    a missing advocate (e.g. P17 crashed) MUST block freeze rather than
+    silently produce a skewed audit. Pass ``expected_count=None`` to opt
+    out (e.g. for ad-hoc scripts).
+    """
+    base = Path(directory)
+    if not base.is_dir():
+        raise FileNotFoundError(f"advocate dir not found: {base}")
+    cards: list[dict] = []
+    for fp in sorted(base.glob("P*.json")):
+        try:
+            cards.append(json.loads(fp.read_text(encoding="utf-8")))
+        except json.JSONDecodeError as e:
+            raise ValueError(f"{fp}: invalid JSON ({e})") from e
+    if expected_count is not None and len(cards) != expected_count:
+        raise ValueError(
+            f"advocate card count {len(cards)} != expected {expected_count} "
+            f"in {base} (a missing P*.json blocks freeze per C-5 contract)"
+        )
+    return cards
+
+
+def framework_distribution(cards: Iterable[dict]) -> dict[str, int]:
+    """Count canonical framework labels across the given cards.
+
+    Cards whose ``spec_alignment_notes`` contains no recognised token are
+    bucketed under ``"unknown"``. Returns a dict label -> count, keyed
+    insertion-order preserved.
+    """
+    dist: dict[str, int] = {}
+    for card in cards:
+        label = extract_framework(card.get("spec_alignment_notes", "")) or "unknown"
+        dist[label] = dist.get(label, 0) + 1
+    return dist

--- a/scripts/generate-spec-anchor-audit.py
+++ b/scripts/generate-spec-anchor-audit.py
@@ -181,6 +181,12 @@ def build_audit(
     if filled_ratio < LOW_CONFIDENCE_THRESHOLD:
         audit["low_confidence"] = True
 
+    # Mirror the spec's _schema_version so downstream consumers can detect the
+    # audit format version they are processing (parity with idea.spec.json).
+    spec_version = spec.get("_schema_version")
+    if isinstance(spec_version, str) and spec_version:
+        audit["_schema_version"] = spec_version
+
     return audit
 
 

--- a/scripts/generate-spec-anchor-audit.py
+++ b/scripts/generate-spec-anchor-audit.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""C-5 spec-anchor-audit generator (issue #62).
+
+Produces ``runs/<id>/spec-anchor-audit.json`` (or any path passed via
+``-o``) — runtime evidence for the v1.6 marketing claim that 26 advocates
+"CONVERGE on idea.spec.json ground truth". Output validates against
+``plugins/preview-forge/schemas/spec-anchor-audit.schema.json``.
+
+Usage:
+    python3 scripts/generate-spec-anchor-audit.py \\
+        runs/<id>/                            # advocate-card dir (P*.json)
+        runs/<id>/idea.spec.json              # I1 Socratic ground truth
+        -o runs/<id>/spec-anchor-audit.json   # output path (optional)
+
+When ``-o`` is omitted the audit JSON is emitted on stdout.
+
+Run id is derived from the parent dir name of the spec by default; override
+with ``--run-id``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _advocate_parsing import (  # noqa: E402
+    extract_framework,
+    framework_distribution,
+    load_advocate_cards,
+)
+
+# Schema path — used both for validation and as default for `--schema`.
+DEFAULT_SCHEMA = (
+    Path(__file__).resolve().parent.parent
+    / "plugins"
+    / "preview-forge"
+    / "schemas"
+    / "spec-anchor-audit.schema.json"
+)
+
+# Mapping from preview-card primary_surface enum → idea.spec primary_surface.platform
+# canonical values. Used by `matches_spec_surface`. Buckets that don't map cleanly
+# fall back to "unknown" so the audit remains deterministic.
+SURFACE_TO_PLATFORM: dict[str, str] = {
+    "Web PWA": "web",
+    "Mobile Web": "web",
+    "iOS Native": "mobile",
+    "Android Native": "mobile",
+    "Slack Bot": "hybrid",
+    "Discord Bot": "hybrid",
+    "CLI": "desktop",
+    "Terminal TUI": "desktop",
+    "Desktop App": "desktop",
+    "Browser Extension": "web",
+    "Email": "hybrid",
+    "SMS/Voice": "hybrid",
+    "AR/VR": "hybrid",
+    "Embedded SDK": "api",
+    "API Only": "api",
+}
+
+LOW_CONFIDENCE_THRESHOLD = 0.2
+DEFAULT_CONVERGENCE_THRESHOLD = 3
+
+
+def _matches_persona(spec_persona: dict | None, advocate_persona: str) -> bool:
+    if not spec_persona or not advocate_persona:
+        return False
+    profile = (spec_persona.get("profile") or "").strip().lower()
+    if not profile or profile == "unknown":
+        return False
+    return profile in advocate_persona.strip().lower() or advocate_persona.strip().lower() in profile
+
+
+def _matches_surface(spec_surface: dict | None, advocate_surface: str) -> bool:
+    if not spec_surface or not advocate_surface:
+        return False
+    platform = (spec_surface.get("platform") or "").strip().lower()
+    if not platform or platform == "unknown":
+        return False
+    expected = SURFACE_TO_PLATFORM.get(advocate_surface, "")
+    return expected == platform
+
+
+def _framework_jaccard(dist: dict[str, int]) -> float:
+    """Max-bucket-share over named (non-unknown) buckets.
+
+    Returns 0.0 when no advocate produced a framework token.
+    """
+    named_total = sum(v for k, v in dist.items() if k != "unknown")
+    if named_total == 0:
+        return 0.0
+    top = max(v for k, v in dist.items() if k != "unknown")
+    return round(top / named_total, 4)
+
+
+SPEC_REQUIRED_FIELDS = ("idea_summary", "_filled_ratio", "_schema_version")
+
+
+def _load_and_validate_spec(spec_path: Path) -> dict[str, Any]:
+    """Load idea.spec.json and assert required fields exist.
+
+    Per C-5 contract, a malformed spec (missing required fields) MUST block
+    freeze — falling through with default 0.0 for `_filled_ratio` would
+    misreport a bad spec as merely `low_confidence` and emit a schema-valid
+    but lying audit. Raise ValueError so generate-spec-anchor-audit.py exits
+    1 (the freeze-blocking signal).
+    """
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    missing = [f for f in SPEC_REQUIRED_FIELDS if f not in spec]
+    if missing:
+        raise ValueError(
+            f"{spec_path}: idea.spec.json missing required fields {missing} "
+            "(C-5 contract: malformed spec blocks freeze)"
+        )
+    return spec
+
+
+def build_audit(
+    advocate_dir: Path,
+    spec_path: Path,
+    run_id: str,
+    threshold: int = DEFAULT_CONVERGENCE_THRESHOLD,
+) -> dict[str, Any]:
+    cards = load_advocate_cards(advocate_dir)
+    spec = _load_and_validate_spec(spec_path)
+
+    spec_persona = spec.get("target_persona")
+    spec_surface = spec.get("primary_surface")
+    filled_ratio = float(spec.get("_filled_ratio", 0.0))
+
+    alignments: list[dict[str, Any]] = []
+    for card in cards:
+        notes = card.get("spec_alignment_notes", "") or ""
+        alignments.append(
+            {
+                "advocate_id": card.get("id"),
+                "spec_field_interpretations": notes,
+                "framework_choice": extract_framework(notes),
+                "matches_spec_persona": _matches_persona(spec_persona, card.get("target_persona", "")),
+                "matches_spec_surface": _matches_surface(spec_surface, card.get("primary_surface", "")),
+            }
+        )
+
+    dist = framework_distribution(cards)
+    named = {k: v for k, v in dist.items() if k != "unknown"}
+    distinct_count = len(named)
+
+    diverged: list[str] = []
+    if distinct_count > threshold:
+        top_labels = {
+            label
+            for label, _ in sorted(named.items(), key=lambda kv: (-kv[1], kv[0]))[:threshold]
+        }
+        diverged = sorted(
+            a["advocate_id"]
+            for a in alignments
+            if a["framework_choice"] is not None and a["framework_choice"] not in top_labels
+        )
+
+    persona_distinct = len({(c.get("target_persona") or "").strip().lower() for c in cards if c.get("target_persona")})
+    surface_distinct = len({c.get("primary_surface") for c in cards if c.get("primary_surface")})
+
+    audit: dict[str, Any] = {
+        "run_id": run_id,
+        "spec_filled_ratio": filled_ratio,
+        "advocate_alignments": alignments,
+        "convergence_metrics": {
+            "framework_jaccard": _framework_jaccard(dist),
+            "persona_distinct_count": persona_distinct,
+            "surface_distinct_count": surface_distinct,
+            "diverged_advocates": diverged,
+            "convergence_threshold": threshold,
+        },
+    }
+    if filled_ratio < LOW_CONFIDENCE_THRESHOLD:
+        audit["low_confidence"] = True
+
+    return audit
+
+
+def _validate(audit: dict, schema_path: Path) -> None:
+    """Best-effort validation. Falls back to a schema-shape sanity check
+    when ``jsonschema`` is not installed so this script still works on
+    minimal CI runners (verify-plugin.sh handles the strict schema check)."""
+    try:
+        import jsonschema  # type: ignore
+    except ImportError:
+        # Minimal structural check — required keys at the top level.
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        for key in schema.get("required", []):
+            if key not in audit:
+                raise ValueError(f"audit missing required key: {key}")
+        return
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=audit, schema=schema)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="generate-spec-anchor-audit",
+        description="C-5 spec-anchor-audit artifact generator.",
+    )
+    parser.add_argument("advocate_dir", help="Directory of P*.json advocate cards.")
+    parser.add_argument("spec_path", help="Path to idea.spec.json.")
+    parser.add_argument("-o", "--output", help="Write audit JSON to this path (default stdout).")
+    parser.add_argument("--run-id", help="Run id (default: parent dir name of spec).")
+    parser.add_argument(
+        "-t",
+        "--threshold",
+        type=int,
+        default=DEFAULT_CONVERGENCE_THRESHOLD,
+        help="Convergence threshold (default: 3).",
+    )
+    parser.add_argument("--schema", default=str(DEFAULT_SCHEMA))
+    args = parser.parse_args(argv)
+
+    advocate_dir = Path(args.advocate_dir)
+    spec_path = Path(args.spec_path)
+    run_id = args.run_id or spec_path.resolve().parent.name
+
+    try:
+        audit = build_audit(advocate_dir, spec_path, run_id, args.threshold)
+        _validate(audit, Path(args.schema))
+    except (FileNotFoundError, ValueError) as e:
+        print(f"generate-spec-anchor-audit: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:  # jsonschema.ValidationError or similar
+        print(f"generate-spec-anchor-audit: schema validation failed: {e}", file=sys.stderr)
+        return 2
+
+    payload = json.dumps(audit, indent=2, sort_keys=False) + "\n"
+    if args.output:
+        Path(args.output).write_text(payload, encoding="utf-8")
+    else:
+        sys.stdout.write(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint-framework-convergence.py
+++ b/scripts/lint-framework-convergence.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""A-6 framework convergence lint (issue #59 sub-task).
+
+Reads a directory of 26 advocate preview-card JSONs and emits a convergence
+report on stdout. Exits 2 when the count of distinct frameworks (excluding
+the ``unknown`` bucket) exceeds the threshold (default 3) so I_LEAD can
+branch on the exit code in the dispatcher pseudocode at
+`agents/ideation/diversity-validator.md` §4.
+
+Canonical regex source-of-truth lives in :mod:`scripts._advocate_parsing`
+(``FRAMEWORK_TOKENS``) so this script and ``generate-spec-anchor-audit.py``
+extract framework choices identically.
+
+Usage:
+    python3 scripts/lint-framework-convergence.py <advocate-dir> [-t N]
+
+Example output (stdout, JSON):
+    {
+      "advocate_count": 26,
+      "frameworks_detected": {"react": 18, "nextjs": 5, "svelte": 2, "unknown": 1},
+      "distinct_count": 3,
+      "convergence_threshold": 3,
+      "warning": false,
+      "diverged_advocates": []
+    }
+
+Exit codes:
+    0 — distinct_count <= threshold (converged)
+    2 — distinct_count >  threshold (warning, retry advocates listed)
+    1 — usage / IO error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Allow running as a script (no package). The shared parser sits next to
+# us under scripts/.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _advocate_parsing import (  # noqa: E402  (after sys.path manipulation)
+    extract_framework,
+    framework_distribution,
+    load_advocate_cards,
+)
+
+
+def build_report(advocate_dir: Path, threshold: int) -> tuple[dict, list[str]]:
+    """Return (report_dict, diverged_advocates).
+
+    ``diverged_advocates`` is the subset of advocate ids whose
+    ``framework_choice`` falls outside the top ``threshold`` buckets, ordered
+    by ascending advocate id.
+    """
+    cards = load_advocate_cards(advocate_dir)
+    dist = framework_distribution(cards)
+
+    # distinct_count excludes the "unknown" bucket since cards with no
+    # framework token don't contribute to divergence.
+    named = {k: v for k, v in dist.items() if k != "unknown"}
+    distinct_count = len(named)
+
+    warning = distinct_count > threshold
+
+    # Identify the top-`threshold` buckets by descending count, ties broken
+    # alphabetically for determinism. Anything outside that set is "diverged".
+    top_labels = {
+        label
+        for label, _ in sorted(named.items(), key=lambda kv: (-kv[1], kv[0]))[:threshold]
+    }
+    diverged: list[str] = []
+    if warning:
+        for card in cards:
+            label = extract_framework(card.get("spec_alignment_notes", ""))
+            if label is None or label in top_labels:
+                continue
+            diverged.append(card.get("id", "?"))
+        diverged.sort()
+
+    report = {
+        "advocate_count": len(cards),
+        "frameworks_detected": dist,
+        "distinct_count": distinct_count,
+        "convergence_threshold": threshold,
+        "warning": warning,
+        "diverged_advocates": diverged,
+    }
+    return report, diverged
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="lint-framework-convergence",
+        description="A-6 framework convergence lint over 26 advocate cards.",
+    )
+    parser.add_argument(
+        "advocate_dir",
+        help="Directory containing P*.json advocate preview-card outputs.",
+    )
+    parser.add_argument(
+        "-t",
+        "--threshold",
+        type=int,
+        default=3,
+        help="Maximum distinct framework count before warning (default: 3).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report, _diverged = build_report(Path(args.advocate_dir), args.threshold)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"lint-framework-convergence: {e}", file=sys.stderr)
+        return 1
+
+    json.dump(report, sys.stdout, indent=2, sort_keys=False)
+    sys.stdout.write("\n")
+    return 2 if report["warning"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/spec-anchor-convergence/_make_fixtures.py
+++ b/tests/fixtures/spec-anchor-convergence/_make_fixtures.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Generate the 3 fixture cases for tests/fixtures/spec-anchor-convergence/.
+
+Run once when fixtures need refreshing:
+    python3 tests/fixtures/spec-anchor-convergence/_make_fixtures.py
+
+Idempotent — overwrites existing P*.json + idea.spec.json + expected-audit.json.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+
+CARD_TEMPLATE = {
+    "advocate": "fixture-advocate",
+    "framing": "Mock framing for spec-anchor-audit fixture, ≥20 chars.",
+    "target_persona": "solo founder",
+    "primary_surface": "Web PWA",
+    "opus_4_7_capability": "code-generation",
+    "mvp_scope": "demo",
+    "one_liner_pitch": "Mock pitch.",
+    "mockup_path": "mockups/PXX-fixture.html",
+    "spec_alignment_notes": "TO_FILL",
+}
+
+
+def make_card(idx: int, notes: str, surface: str = "Web PWA", persona: str = "solo founder") -> dict:
+    pid = f"P{idx:02d}"
+    card = dict(CARD_TEMPLATE)
+    card["id"] = pid
+    card["spec_alignment_notes"] = notes
+    card["primary_surface"] = surface
+    card["target_persona"] = persona
+    card["mockup_path"] = f"mockups/{pid}-fixture.html"
+    return card
+
+
+def write_dir(path: Path, cards: list[dict], spec: dict) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    for card in cards:
+        (path / f"{card['id']}.json").write_text(
+            json.dumps(card, indent=2) + "\n", encoding="utf-8"
+        )
+    (path / "idea.spec.json").write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+
+
+# -------- Case A: aligned (all React) --------
+aligned_cards = [
+    make_card(i, "all fields populated, followed spec verbatim — using React for the Web PWA stack")
+    for i in range(1, 27)
+]
+aligned_spec = {
+    "idea_summary": "Solo-founder React PWA",
+    "target_persona": {"profile": "solo founder", "primary_pain": None, "usage_frequency": None},
+    "primary_surface": {"platform": "web", "sync_model": None, "offline_capable": None},
+    "_filled_ratio": 0.5,
+    "_schema_version": "1.7.0",
+}
+write_dir(ROOT / "case-aligned", aligned_cards, aligned_spec)
+
+# -------- Case B: divergent (4 distinct frameworks) --------
+# 10× react, 8× nextjs, 5× svelte, 3× vue — 4 distinct, threshold=3 → warning,
+# the 4th (vue) bucket diverges → P24..P26 flagged.
+divergent_notes = (
+    [("react", "Building a React SPA front-end for the Web PWA target")] * 10
+    + [("nextjs", "Next.js SSR for the Web PWA primary_surface")] * 8
+    + [("svelte", "Plain Svelte for the Web PWA, lighter bundle")] * 5
+    + [("vue", "Vue.js for the Web PWA — team familiarity")] * 3
+)
+divergent_cards = [
+    make_card(i + 1, divergent_notes[i][1]) for i in range(26)
+]
+divergent_spec = dict(aligned_spec)
+write_dir(ROOT / "case-divergent", divergent_cards, divergent_spec)
+
+# -------- Case C: low confidence (filled_ratio = 0.15) --------
+low_conf_cards = [
+    make_card(i, "spec persona unknown → assumed solo founder; using React for Web PWA")
+    for i in range(1, 27)
+]
+low_conf_spec = {
+    "idea_summary": "Vague seed",
+    "target_persona": {"profile": None, "primary_pain": None, "usage_frequency": None},
+    "primary_surface": {"platform": None, "sync_model": None, "offline_capable": None},
+    "_filled_ratio": 0.15,
+    "_schema_version": "1.7.0",
+}
+write_dir(ROOT / "case-low-confidence", low_conf_cards, low_conf_spec)
+
+print("Fixtures generated:")
+for d in ["case-aligned", "case-divergent", "case-low-confidence"]:
+    n = len(list((ROOT / d).glob("P*.json")))
+    print(f"  {d}: {n} advocate cards")

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P01.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P01.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P01-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P01"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P02.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P02.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P02-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P02"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P03.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P03.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P03-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P03"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P04.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P04.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P04-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P04"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P05.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P05.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P05-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P05"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P06.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P06.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P06-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P06"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P07.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P07.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P07-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P07"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P08.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P08.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P08-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P08"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P09.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P09.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P09-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P09"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P10.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P10.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P10-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P10"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P11.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P11.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P11-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P11"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P12.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P12.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P12-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P12"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P13.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P13.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P13-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P13"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P14.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P14.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P14-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P14"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P15.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P15.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P15-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P15"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P16.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P16.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P16-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P16"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P17.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P17.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P17-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P17"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P18.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P18.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P18-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P18"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P19.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P19.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P19-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P19"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P20.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P20.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P20-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P20"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P21.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P21.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P21-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P21"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P22.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P22.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P22-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P22"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P23.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P23.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P23-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P23"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P24.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P24.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P24-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P24"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P25.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P25.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P25-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P25"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/P26.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/P26.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P26-fixture.html",
+  "spec_alignment_notes": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+  "id": "P26"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/expected-audit.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/expected-audit.json
@@ -1,0 +1,195 @@
+{
+  "run_id": "case-aligned",
+  "spec_filled_ratio": 0.5,
+  "advocate_alignments": [
+    {
+      "advocate_id": "P01",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P02",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P03",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P04",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P05",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P06",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P07",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P08",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P09",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P10",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P11",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P12",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P13",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P14",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P15",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P16",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P17",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P18",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P19",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P20",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P21",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P22",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P23",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P24",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P25",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P26",
+      "spec_field_interpretations": "all fields populated, followed spec verbatim \u2014 using React for the Web PWA stack",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    }
+  ],
+  "convergence_metrics": {
+    "framework_jaccard": 1.0,
+    "persona_distinct_count": 1,
+    "surface_distinct_count": 1,
+    "diverged_advocates": [],
+    "convergence_threshold": 3
+  }
+}

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/expected-audit.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/expected-audit.json
@@ -191,5 +191,6 @@
     "surface_distinct_count": 1,
     "diverged_advocates": [],
     "convergence_threshold": 3
-  }
+  },
+  "_schema_version": "1.7.0"
 }

--- a/tests/fixtures/spec-anchor-convergence/case-aligned/idea.spec.json
+++ b/tests/fixtures/spec-anchor-convergence/case-aligned/idea.spec.json
@@ -1,0 +1,15 @@
+{
+  "idea_summary": "Solo-founder React PWA",
+  "target_persona": {
+    "profile": "solo founder",
+    "primary_pain": null,
+    "usage_frequency": null
+  },
+  "primary_surface": {
+    "platform": "web",
+    "sync_model": null,
+    "offline_capable": null
+  },
+  "_filled_ratio": 0.5,
+  "_schema_version": "1.7.0"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P01.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P01.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P01-fixture.html",
+  "spec_alignment_notes": "Building a React SPA front-end for the Web PWA target",
+  "id": "P01"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P02.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P02.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P02-fixture.html",
+  "spec_alignment_notes": "Building a React SPA front-end for the Web PWA target",
+  "id": "P02"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P03.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P03.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P03-fixture.html",
+  "spec_alignment_notes": "Building a React SPA front-end for the Web PWA target",
+  "id": "P03"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P04.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P04.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P04-fixture.html",
+  "spec_alignment_notes": "Building a React SPA front-end for the Web PWA target",
+  "id": "P04"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P05.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P05.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P05-fixture.html",
+  "spec_alignment_notes": "Building a React SPA front-end for the Web PWA target",
+  "id": "P05"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P06.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P06.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P06-fixture.html",
+  "spec_alignment_notes": "Building a React SPA front-end for the Web PWA target",
+  "id": "P06"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P07.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P07.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P07-fixture.html",
+  "spec_alignment_notes": "Building a React SPA front-end for the Web PWA target",
+  "id": "P07"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P08.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P08.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P08-fixture.html",
+  "spec_alignment_notes": "Building a React SPA front-end for the Web PWA target",
+  "id": "P08"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P09.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P09.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P09-fixture.html",
+  "spec_alignment_notes": "Building a React SPA front-end for the Web PWA target",
+  "id": "P09"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P10.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P10.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P10-fixture.html",
+  "spec_alignment_notes": "Building a React SPA front-end for the Web PWA target",
+  "id": "P10"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P11.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P11.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P11-fixture.html",
+  "spec_alignment_notes": "Next.js SSR for the Web PWA primary_surface",
+  "id": "P11"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P12.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P12.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P12-fixture.html",
+  "spec_alignment_notes": "Next.js SSR for the Web PWA primary_surface",
+  "id": "P12"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P13.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P13.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P13-fixture.html",
+  "spec_alignment_notes": "Next.js SSR for the Web PWA primary_surface",
+  "id": "P13"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P14.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P14.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P14-fixture.html",
+  "spec_alignment_notes": "Next.js SSR for the Web PWA primary_surface",
+  "id": "P14"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P15.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P15.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P15-fixture.html",
+  "spec_alignment_notes": "Next.js SSR for the Web PWA primary_surface",
+  "id": "P15"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P16.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P16.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P16-fixture.html",
+  "spec_alignment_notes": "Next.js SSR for the Web PWA primary_surface",
+  "id": "P16"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P17.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P17.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P17-fixture.html",
+  "spec_alignment_notes": "Next.js SSR for the Web PWA primary_surface",
+  "id": "P17"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P18.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P18.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P18-fixture.html",
+  "spec_alignment_notes": "Next.js SSR for the Web PWA primary_surface",
+  "id": "P18"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P19.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P19.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P19-fixture.html",
+  "spec_alignment_notes": "Plain Svelte for the Web PWA, lighter bundle",
+  "id": "P19"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P20.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P20.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P20-fixture.html",
+  "spec_alignment_notes": "Plain Svelte for the Web PWA, lighter bundle",
+  "id": "P20"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P21.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P21.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P21-fixture.html",
+  "spec_alignment_notes": "Plain Svelte for the Web PWA, lighter bundle",
+  "id": "P21"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P22.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P22.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P22-fixture.html",
+  "spec_alignment_notes": "Plain Svelte for the Web PWA, lighter bundle",
+  "id": "P22"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P23.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P23.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P23-fixture.html",
+  "spec_alignment_notes": "Plain Svelte for the Web PWA, lighter bundle",
+  "id": "P23"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P24.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P24.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P24-fixture.html",
+  "spec_alignment_notes": "Vue.js for the Web PWA \u2014 team familiarity",
+  "id": "P24"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P25.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P25.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P25-fixture.html",
+  "spec_alignment_notes": "Vue.js for the Web PWA \u2014 team familiarity",
+  "id": "P25"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/P26.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/P26.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P26-fixture.html",
+  "spec_alignment_notes": "Vue.js for the Web PWA \u2014 team familiarity",
+  "id": "P26"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/expected-audit.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/expected-audit.json
@@ -195,5 +195,6 @@
       "P26"
     ],
     "convergence_threshold": 3
-  }
+  },
+  "_schema_version": "1.7.0"
 }

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/expected-audit.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/expected-audit.json
@@ -1,0 +1,199 @@
+{
+  "run_id": "case-divergent",
+  "spec_filled_ratio": 0.5,
+  "advocate_alignments": [
+    {
+      "advocate_id": "P01",
+      "spec_field_interpretations": "Building a React SPA front-end for the Web PWA target",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P02",
+      "spec_field_interpretations": "Building a React SPA front-end for the Web PWA target",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P03",
+      "spec_field_interpretations": "Building a React SPA front-end for the Web PWA target",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P04",
+      "spec_field_interpretations": "Building a React SPA front-end for the Web PWA target",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P05",
+      "spec_field_interpretations": "Building a React SPA front-end for the Web PWA target",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P06",
+      "spec_field_interpretations": "Building a React SPA front-end for the Web PWA target",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P07",
+      "spec_field_interpretations": "Building a React SPA front-end for the Web PWA target",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P08",
+      "spec_field_interpretations": "Building a React SPA front-end for the Web PWA target",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P09",
+      "spec_field_interpretations": "Building a React SPA front-end for the Web PWA target",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P10",
+      "spec_field_interpretations": "Building a React SPA front-end for the Web PWA target",
+      "framework_choice": "react",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P11",
+      "spec_field_interpretations": "Next.js SSR for the Web PWA primary_surface",
+      "framework_choice": "nextjs",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P12",
+      "spec_field_interpretations": "Next.js SSR for the Web PWA primary_surface",
+      "framework_choice": "nextjs",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P13",
+      "spec_field_interpretations": "Next.js SSR for the Web PWA primary_surface",
+      "framework_choice": "nextjs",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P14",
+      "spec_field_interpretations": "Next.js SSR for the Web PWA primary_surface",
+      "framework_choice": "nextjs",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P15",
+      "spec_field_interpretations": "Next.js SSR for the Web PWA primary_surface",
+      "framework_choice": "nextjs",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P16",
+      "spec_field_interpretations": "Next.js SSR for the Web PWA primary_surface",
+      "framework_choice": "nextjs",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P17",
+      "spec_field_interpretations": "Next.js SSR for the Web PWA primary_surface",
+      "framework_choice": "nextjs",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P18",
+      "spec_field_interpretations": "Next.js SSR for the Web PWA primary_surface",
+      "framework_choice": "nextjs",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P19",
+      "spec_field_interpretations": "Plain Svelte for the Web PWA, lighter bundle",
+      "framework_choice": "svelte",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P20",
+      "spec_field_interpretations": "Plain Svelte for the Web PWA, lighter bundle",
+      "framework_choice": "svelte",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P21",
+      "spec_field_interpretations": "Plain Svelte for the Web PWA, lighter bundle",
+      "framework_choice": "svelte",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P22",
+      "spec_field_interpretations": "Plain Svelte for the Web PWA, lighter bundle",
+      "framework_choice": "svelte",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P23",
+      "spec_field_interpretations": "Plain Svelte for the Web PWA, lighter bundle",
+      "framework_choice": "svelte",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P24",
+      "spec_field_interpretations": "Vue.js for the Web PWA \u2014 team familiarity",
+      "framework_choice": "vue",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P25",
+      "spec_field_interpretations": "Vue.js for the Web PWA \u2014 team familiarity",
+      "framework_choice": "vue",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    },
+    {
+      "advocate_id": "P26",
+      "spec_field_interpretations": "Vue.js for the Web PWA \u2014 team familiarity",
+      "framework_choice": "vue",
+      "matches_spec_persona": true,
+      "matches_spec_surface": true
+    }
+  ],
+  "convergence_metrics": {
+    "framework_jaccard": 0.3846,
+    "persona_distinct_count": 1,
+    "surface_distinct_count": 1,
+    "diverged_advocates": [
+      "P24",
+      "P25",
+      "P26"
+    ],
+    "convergence_threshold": 3
+  }
+}

--- a/tests/fixtures/spec-anchor-convergence/case-divergent/idea.spec.json
+++ b/tests/fixtures/spec-anchor-convergence/case-divergent/idea.spec.json
@@ -1,0 +1,15 @@
+{
+  "idea_summary": "Solo-founder React PWA",
+  "target_persona": {
+    "profile": "solo founder",
+    "primary_pain": null,
+    "usage_frequency": null
+  },
+  "primary_surface": {
+    "platform": "web",
+    "sync_model": null,
+    "offline_capable": null
+  },
+  "_filled_ratio": 0.5,
+  "_schema_version": "1.7.0"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P01.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P01.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P01-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P01"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P02.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P02.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P02-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P02"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P03.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P03.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P03-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P03"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P04.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P04.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P04-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P04"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P05.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P05.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P05-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P05"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P06.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P06.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P06-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P06"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P07.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P07.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P07-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P07"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P08.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P08.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P08-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P08"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P09.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P09.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P09-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P09"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P10.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P10.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P10-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P10"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P11.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P11.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P11-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P11"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P12.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P12.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P12-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P12"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P13.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P13.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P13-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P13"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P14.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P14.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P14-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P14"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P15.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P15.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P15-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P15"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P16.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P16.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P16-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P16"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P17.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P17.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P17-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P17"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P18.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P18.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P18-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P18"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P19.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P19.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P19-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P19"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P20.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P20.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P20-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P20"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P21.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P21.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P21-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P21"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P22.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P22.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P22-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P22"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P23.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P23.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P23-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P23"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P24.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P24.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P24-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P24"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P25.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P25.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P25-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P25"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/P26.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/P26.json
@@ -1,0 +1,12 @@
+{
+  "advocate": "fixture-advocate",
+  "framing": "Mock framing for spec-anchor-audit fixture, \u226520 chars.",
+  "target_persona": "solo founder",
+  "primary_surface": "Web PWA",
+  "opus_4_7_capability": "code-generation",
+  "mvp_scope": "demo",
+  "one_liner_pitch": "Mock pitch.",
+  "mockup_path": "mockups/P26-fixture.html",
+  "spec_alignment_notes": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+  "id": "P26"
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/expected-audit.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/expected-audit.json
@@ -1,0 +1,196 @@
+{
+  "run_id": "case-low-confidence",
+  "spec_filled_ratio": 0.15,
+  "advocate_alignments": [
+    {
+      "advocate_id": "P01",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P02",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P03",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P04",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P05",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P06",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P07",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P08",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P09",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P10",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P11",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P12",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P13",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P14",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P15",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P16",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P17",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P18",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P19",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P20",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P21",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P22",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P23",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P24",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P25",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    },
+    {
+      "advocate_id": "P26",
+      "spec_field_interpretations": "spec persona unknown \u2192 assumed solo founder; using React for Web PWA",
+      "framework_choice": "react",
+      "matches_spec_persona": false,
+      "matches_spec_surface": false
+    }
+  ],
+  "convergence_metrics": {
+    "framework_jaccard": 1.0,
+    "persona_distinct_count": 1,
+    "surface_distinct_count": 1,
+    "diverged_advocates": [],
+    "convergence_threshold": 3
+  },
+  "low_confidence": true
+}

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/expected-audit.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/expected-audit.json
@@ -192,5 +192,6 @@
     "diverged_advocates": [],
     "convergence_threshold": 3
   },
-  "low_confidence": true
+  "low_confidence": true,
+  "_schema_version": "1.7.0"
 }

--- a/tests/fixtures/spec-anchor-convergence/case-low-confidence/idea.spec.json
+++ b/tests/fixtures/spec-anchor-convergence/case-low-confidence/idea.spec.json
@@ -1,0 +1,15 @@
+{
+  "idea_summary": "Vague seed",
+  "target_persona": {
+    "profile": null,
+    "primary_pain": null,
+    "usage_frequency": null
+  },
+  "primary_surface": {
+    "platform": null,
+    "sync_model": null,
+    "offline_capable": null
+  },
+  "_filled_ratio": 0.15,
+  "_schema_version": "1.7.0"
+}

--- a/tests/fixtures/spec-anchor-convergence/verify.sh
+++ b/tests/fixtures/spec-anchor-convergence/verify.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Verify A-6 framework lint + C-5 spec-anchor-audit against 3 fixture cases.
+#
+# Usage: bash tests/fixtures/spec-anchor-convergence/verify.sh
+#
+# Cases:
+#   case-aligned       — 26× react       → distinct=1, exit 0, jaccard=1.0
+#   case-divergent     — 4 frameworks    → distinct=4, exit 2, diverged=P24..P26
+#   case-low-confidence — filled_ratio=0.15 → low_confidence:true flag
+#
+# Each case is verified by running both scripts and JSON-deep-equal-comparing
+# the audit output against the committed expected-audit.json (jq deepequal).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+FIX="$ROOT/tests/fixtures/spec-anchor-convergence"
+LINT="$ROOT/scripts/lint-framework-convergence.py"
+GEN="$ROOT/scripts/generate-spec-anchor-audit.py"
+
+pass=0
+fail=0
+ok()  { echo "  ✓ $1"; pass=$((pass + 1)); }
+bad() { echo "  ✗ $1" >&2; fail=$((fail + 1)); }
+
+deep_equal() {
+  # JSON-deep-equal via jq; returns 0 when payloads match.
+  # Uses --slurpfile (portable across jq 1.6 / 1.7 / 1.8) instead of the
+  # deprecated --argfile flag.
+  jq --slurpfile a "$1" --slurpfile b "$2" -n '$a == $b' | grep -q true
+}
+
+run_case() {
+  local case_name="$1"
+  local expected_lint_exit="$2"
+  local case_dir="$FIX/$case_name"
+  local spec="$case_dir/idea.spec.json"
+  local expected="$case_dir/expected-audit.json"
+
+  echo "[$case_name]"
+
+  # 1. Lint exit code
+  set +e
+  python3 "$LINT" "$case_dir/" >/tmp/lint-$case_name.json
+  local rc=$?
+  set -e
+  if [[ "$rc" -eq "$expected_lint_exit" ]]; then
+    ok "lint exit code $rc (expected $expected_lint_exit)"
+  else
+    bad "lint exit code $rc (expected $expected_lint_exit)"
+  fi
+
+  # 2. Audit JSON deep-equal expected
+  local actual="/tmp/audit-$case_name.json"
+  python3 "$GEN" "$case_dir/" "$spec" --run-id "$case_name" -o "$actual"
+  if deep_equal "$actual" "$expected"; then
+    ok "audit JSON matches expected-audit.json"
+  else
+    bad "audit JSON drift vs expected-audit.json"
+    diff <(jq -S . "$expected") <(jq -S . "$actual") || true
+  fi
+}
+
+run_case case-aligned 0
+run_case case-divergent 2
+run_case case-low-confidence 0
+
+# Case C extra: low_confidence flag must be present + true.
+if jq -e '.low_confidence == true' "$FIX/case-low-confidence/expected-audit.json" >/dev/null; then
+  ok "case-low-confidence: low_confidence: true flag"
+else
+  bad "case-low-confidence: low_confidence flag missing"
+fi
+
+echo
+echo "=== SUMMARY === Pass: $pass · Fail: $fail"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## Summary

Closes the **A-6** portion of issue #59 (framework_convergence lint had prose-only spec, no script) and closes #62 entirely (spec-anchor-audit artifact for the v1.6 \"26 advocates CONVERGE on idea.spec.json\" claim, previously unmeasured).

- **A-6 lint** — `scripts/lint-framework-convergence.py` (124 LOC) + shared regex helper `scripts/_advocate_parsing.py` (109 LOC). Reads 26 P*.json advocate cards, extracts framework tokens from `spec_alignment_notes`, exits 0/2 so I_LEAD can branch on the dispatcher.
- **C-5 audit** — `scripts/generate-spec-anchor-audit.py` (245 LOC) + new `plugins/preview-forge/schemas/spec-anchor-audit.schema.json` (114 LOC, 6th schema — picked up by the dynamic-count assertion landed in #63). Emits `runs/<id>/spec-anchor-audit.json` with `convergence_metrics` (`framework_jaccard`, `persona_distinct_count`, `surface_distinct_count`, `diverged_advocates`) + `low_confidence` flag when `_filled_ratio < 0.2`.
- **Doc citations** — I2 Diversity Validator §4 + M3 PM end-of-file section, both wrapped in HTML-comment delimiters so W2.7's A-5 region (lines 60-71 in chief-engineer-pm.md) stays untouched.
- **Fixtures** — 3 cases under `tests/fixtures/spec-anchor-convergence/` with deterministic `_make_fixtures.py` source + `verify.sh` JSON-deep-equal harness (jq `--slurpfile` for portability).

## Verification

- `bash scripts/verify-plugin.sh` — Pass: 57 / Fail: 0 (dynamic schema count = 6 detected)
- `bash tests/fixtures/spec-anchor-convergence/verify.sh` — Pass: 7 / Fail: 0 (all 3 cases byte-equal expected)
- `python3 scripts/lint-framework-convergence.py tests/fixtures/spec-anchor-convergence/case-divergent/; echo $?` → `2`
- Manual guard tests:
  - 5-card directory rejected with `count 5 != expected 26` (exit 1)
  - Malformed `idea.spec.json` (missing `_filled_ratio`) rejected (exit 1)

## Codex review (one pass)

- **P1 (applied in this PR)**:
  - Reject `count(P*.json) != 26` in `load_advocate_cards()` so a missing advocate blocks freeze instead of silently producing skewed metrics.
  - Validate `idea.spec.json` required fields before audit generation so a malformed spec exits 1 instead of being misreported as `low_confidence`.
- **P2 (deferred → follow-up issue)**:
  - Tighten framework regexes in `FRAMEWORK_TOKENS` to avoid plain-word false positives (\"Next, validate ...\" currently matches `nextjs`; \"solid backend\" currently matches `solidjs`). Recommended fix: require a `js`/`.js`/explicit framework qualifier suffix, or context-anchor against \"using\"/\"chose\" verbs.
- **P3**: none.

## Test plan

- [x] `verify-plugin.sh` passes with 6 schemas
- [x] `verify.sh` 3-case fixture suite passes
- [x] Lint exit codes match contract (0 / 2 / 1)
- [x] New guards reject < 26 cards and malformed spec
- [ ] Reviewer: confirm M3 chief-engineer-pm.md C-5 section does not collide with W2.7's A-5 section once both PRs merge

## Out of scope (per plan)

- A-4 / A-5 enforcement scripts (`filled-ratio-gate.sh`, `h1-modal-helper.sh`) — W2.7 territory
- Advocate boilerplate sync — W2.6 territory
- ideation-lead.md edits — W2.7 territory

🤖 Generated with [Claude Code](https://claude.com/claude-code)