### PR TITLE
feat(ideation,meta): A-4 filled-ratio gate + A-5 H1 modal helper (#59)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
           bash tests/fixtures/security/verify-security.sh
           bash tests/fixtures/rule9-fp-guard/verify-rule9.sh
           bash tests/fixtures/filled-ratio/verify-filled-ratio.sh
+          bash tests/fixtures/filled-ratio-gating/verify.sh
+          bash tests/fixtures/h1-modal-swap/verify.sh
           bash tests/fixtures/normalize-constraints/verify-normalize.sh
           bash tests/fixtures/lesson07-regression/verify-lesson07.sh
           bash tests/fixtures/seed-expectations/verify-seed-expectations.sh

--- a/plugins/preview-forge/agents/ideation/ideation-lead.md
+++ b/plugins/preview-forge/agents/ideation/ideation-lead.md
@@ -38,6 +38,31 @@ model: opus
 
   hard gate 없음 — 해커톤 데모 UX 우선. weak-replay short-circuit이 먼저 걸러졌다면 이 경로에는 도달하지 않는다. I_LEAD는 Bash 도구가 없으므로 stderr 대신 Blackboard로 기록.
 
+<!-- A-4 enforcement section (PR W2.7 / issue #59) -->
+#### Enforcement (A-4)
+
+위 4-tier cascade는 더 이상 prompt-only 가이드가 아니다. `scripts/filled-ratio-gate.sh`가 canonical computation이며, I_LEAD는 §2 advocate dispatch **직전**에 반드시 이 wrapper를 호출하여 그 출력의 `mode=...`로 IDEA_SPEC splice 여부를 결정해야 한다. 이 스크립트는 `scripts/compute-filled-ratio.py`를 위임 호출하므로 슬롯 규칙은 한 군데(파이썬 스크립트)에서만 정의된다.
+
+```bash
+# mode + ratio 라인을 받아오는 형태
+eval "$(bash scripts/filled-ratio-gate.sh runs/<id>/idea.spec.json)"
+# $mode ∈ {ground-truth, hint, low-confidence, fallback-omit-spec}
+
+case "$mode" in
+  ground-truth)        # ratio ≥ 0.7  → IDEA_SPEC을 ground truth로 splice (위 표 'high')
+    ;;
+  hint)                # 0.4 ≤ r < 0.7 → IDEA_SPEC을 hint로 splice  (위 표 'medium')
+    ;;
+  low-confidence)      # 0.2 ≤ r < 0.4 → IDEA_SPEC 약한 hint        (위 표 'low')
+    ;;
+  fallback-omit-spec)  # r < 0.2  → IDEA_SPEC 라인 자체를 빼고 v1.5.4 marker만 (위 표 'fallback')
+    ;;
+esac
+```
+
+`--prompt-fragment` 플래그를 쓰면 advocate 프롬프트에 그대로 붙일 byte-stable 텍스트 블록을 얻을 수 있다 (fallback tier에서는 `IDEA_SPEC_CONFIDENCE` 라인이 의도적으로 누락됨 — A-4 contract). 회귀 테스트: `tests/fixtures/filled-ratio-gating/verify.sh`가 ratio=0.11 / 0.44 / 0.78 케이스에서 mode 값과 fragment 내용이 byte-equal인지 어설션한다.
+<!-- end A-4 -->
+
 - I1 호출 자체가 실패(user abort 등)하면 Blackboard에 `ideation.spec_missing` 기록하고 M3에 escalate
 
 ### 2. Profile-aware Advocate 병렬 dispatch

--- a/plugins/preview-forge/agents/meta/chief-engineer-pm.md
+++ b/plugins/preview-forge/agents/meta/chief-engineer-pm.md
@@ -78,6 +78,32 @@ Standup 결과를 Blackboard에 `standup.<cycle>.<ts>` key로 기록.
 
 **H2 (TestDD freeze → 배포)**: 500점 리포트 + 스크린샷 + 배포 대상을 AskUserQuestion 옵션으로 제시, 승인 시 `/pf:export` 워크플로 트리거
 
+<!-- A-5 enforcement section (PR W2.7 / issue #59) -->
+#### Gate H1 swap algorithm (A-5)
+
+위 §3 절차 3~4의 swap 규칙(exit 0 ⇒ 갤러리 옵션 ④, exit 3 ⇒ 인라인 옵션 ④)은 더 이상 markdown bullet에만 의존하지 않는다. `scripts/h1-modal-helper.sh`가 `open-browser.sh` 종료 코드를 capture해 단일 JSON 라인으로 mode를 emit하므로 M3는 정해진 분기 알고리즘만 따르면 된다.
+
+```bash
+decision=$(bash "${CLAUDE_PLUGIN_ROOT}/../../scripts/h1-modal-helper.sh" \
+                 "runs/<id>/mockups/gallery.html")
+case "$(printf '%s' "$decision" | python3 -c 'import sys,json; print(json.loads(sys.stdin.read())["mode"])')" in
+  browser)
+    # open-browser.sh exit 0 — 사용자는 갤러리를 보고 있다.
+    # AskUserQuestion 옵션 ④ = "🎨 Pick from gallery"
+    ;;
+  inline)
+    # open-browser.sh exit 3 — headless / CI / SSH-without-DISPLAY.
+    # AskUserQuestion 옵션 ④ = "📜 Pick from full inline list" + cat gallery-text.md
+    ;;
+  error)
+    # exit 1 (S-2 reject 등) — H1을 에러로 중단하고 사용자에게 알려야 한다.
+    ;;
+esac
+```
+
+`mode=inline`은 정상 분기이며 helper는 exit 0을 반환한다 (swap은 에러가 아니라 기대된 alternative path). `mode=error`만 helper 자체가 비-0 exit code로 propagate한다. 회귀 테스트: `tests/fixtures/h1-modal-swap/verify.sh`가 PATH-stripped 환경(`open`/`xdg-open`/`powershell.exe`/`pwsh` 부재)에서 byte-equal `{"mode":"inline",...}` 출력을, 가짜 `open` shim 환경에서 byte-equal `{"mode":"browser",...}` 출력을 어설션한다.
+<!-- end A-5 -->
+
 ### 4. Memory 파일 관리 (쓰기 권한 독점)
 
 **Rule 3**에 따라 당신만 `memory/{CLAUDE,PROGRESS,LESSONS}.md`에 쓸 수 있습니다. 다른 agent는 Blackboard에 `memory.request.{file}` 키로 요청 → 당신이 검토 후 batch 반영.

--- a/scripts/filled-ratio-gate.sh
+++ b/scripts/filled-ratio-gate.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Preview Forge — A-4 filled_ratio dispatch gate (v1.11.0+).
+#
+# Turns the 4-tier `_filled_ratio` cascade documented in
+# `agents/ideation/ideation-lead.md` (PR #59 A-4) from prompt-only
+# guidance into a script-enforced contract. I_LEAD invokes this BEFORE
+# dispatching the N advocates and uses the printed `mode=...` line to
+# decide whether to splice IDEA_SPEC into each advocate prompt.
+#
+# Computation: delegated to `scripts/compute-filled-ratio.py`. We never
+# duplicate the slot rule — that script is the canonical source.
+#
+# Exit code:
+#   0 — mode emitted to stdout (always; the mode is informational and
+#       the consumer decides how to act).
+#   2 — bad args / compute-filled-ratio.py error (parse error, missing
+#       file, …). stderr from the python script is propagated.
+#
+# Output (stdout) without --prompt-fragment:
+#   ratio=<float, 4 decimals>
+#   mode=<ground-truth | hint | low-confidence | fallback-omit-spec>
+#
+# Output (stdout) with --prompt-fragment: a ready-to-splice block of
+# text that I_LEAD can paste verbatim under `IDEA_SPEC:` in the
+# advocate dispatch template (see ideation-lead.md §2). For the
+# fallback tier the fragment is the literal v1.5.4 marker line; the
+# advocate receives no spec content.
+#
+# Mapping (must stay in lockstep with ideation-lead.md §1 table):
+#   ratio >= 0.7   → mode=ground-truth      → IDEA_SPEC_CONFIDENCE: high
+#   0.4 ≤ r < 0.7  → mode=hint              → IDEA_SPEC_CONFIDENCE: medium
+#   0.2 ≤ r < 0.4  → mode=low-confidence    → IDEA_SPEC_CONFIDENCE: low
+#   r < 0.2        → mode=fallback-omit-spec → spec NOT spliced (v1.5.4 path)
+
+set -u
+
+usage() {
+  cat >&2 <<'EOF'
+usage: filled-ratio-gate.sh [--prompt-fragment] <idea.spec.json>
+
+  --prompt-fragment   emit the IDEA_SPEC splice fragment instead of the
+                      key=value pair lines. Output is byte-stable for
+                      direct concatenation into advocate prompts.
+EOF
+}
+
+emit_fragment=0
+spec_path=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --prompt-fragment) emit_fragment=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; spec_path="${1:-}"; shift || true; break ;;
+    -*) echo "filled-ratio-gate.sh: unknown flag: $1" >&2; usage; exit 2 ;;
+    *)  spec_path="$1"; shift ;;
+  esac
+done
+
+if [ -z "${spec_path:-}" ]; then
+  usage
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+COMPUTE="$SCRIPT_DIR/compute-filled-ratio.py"
+
+if [ ! -r "$COMPUTE" ]; then
+  echo "filled-ratio-gate.sh: compute-filled-ratio.py not readable at $COMPUTE" >&2
+  exit 2
+fi
+
+# Delegate ratio computation. The python script exits 2 on parse error.
+ratio=$(python3 "$COMPUTE" "$spec_path") || exit 2
+
+# Tier mapping. Use python for the float compare so awk locale (LC_NUMERIC)
+# differences don't flip a decimal-point comparison on macOS vs Linux.
+# Fail-closed: if python3 is missing or the heredoc cannot be created
+# (sandboxed CI / locked-down /tmp), we MUST exit non-zero rather than
+# print `mode=` and pretend the gate succeeded. Codex review caught
+# this — silent empty mode breaks the A-4 contract.
+mode=$(python3 - "$ratio" <<'PY'
+import sys
+r = float(sys.argv[1])
+if r >= 0.7:
+    print("ground-truth")
+elif r >= 0.4:
+    print("hint")
+elif r >= 0.2:
+    print("low-confidence")
+else:
+    print("fallback-omit-spec")
+PY
+) || {
+  echo "filled-ratio-gate.sh: python3 tier-mapping step failed" >&2
+  exit 2
+}
+if [ -z "$mode" ]; then
+  echo "filled-ratio-gate.sh: tier-mapping produced empty mode" >&2
+  exit 2
+fi
+
+if [ "$emit_fragment" -eq 1 ]; then
+  case "$mode" in
+    ground-truth)
+      printf 'IDEA_SPEC_CONFIDENCE: high\nIDEA_SPEC: <splice runs/<id>/idea.spec.json verbatim — ground truth>\n'
+      ;;
+    hint)
+      printf 'IDEA_SPEC_CONFIDENCE: medium\nIDEA_SPEC: <splice runs/<id>/idea.spec.json — hint, free-interpret null/"unknown" fields>\n'
+      ;;
+    low-confidence)
+      printf 'IDEA_SPEC_CONFIDENCE: low\nIDEA_SPEC: <splice runs/<id>/idea.spec.json — weak hint, large divergence allowed>\n'
+      ;;
+    fallback-omit-spec)
+      # v1.5.4 path: spec is NOT delivered; confidence line is also dropped.
+      printf 'IDEA_SPEC: <not provided — fallback v1.5.4 path>\n'
+      ;;
+  esac
+  exit 0
+fi
+
+printf 'ratio=%s\n' "$ratio"
+printf 'mode=%s\n' "$mode"
+exit 0

--- a/scripts/h1-modal-helper.sh
+++ b/scripts/h1-modal-helper.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Preview Forge — A-5 H1 modal swap helper (v1.11.0+).
+#
+# Wraps `scripts/open-browser.sh` so M3 Chief Engineer (Gate H1) can
+# tell — in machine-readable form — whether option ④ should be the
+# "🎨 Pick from gallery" (browser opened) or the "📜 Pick from full
+# inline list" headless fallback. Previously the swap rule lived only
+# as bullet-points in `agents/meta/chief-engineer-pm.md §3 Gate H1`,
+# so a future markdown rewrite could silently regress the contract.
+#
+# Contract:
+#   - exit 0 from open-browser.sh (browser launched)
+#       → stdout: {"mode":"browser","url":"<url>"}
+#       → exit:   0
+#   - exit 3 from open-browser.sh (no opener — headless / CI / SSH)
+#       → stdout: {"mode":"inline","url":"<url>"}
+#       → exit:   0   (the swap is a normal, expected branch — NOT an error)
+#   - any other exit code (1 = bad args / S-2 reject, …)
+#       → stdout: {"mode":"error","exit_code":<n>,"url":"<url>"}
+#       → exit:   <n>  (propagated so CI / orchestration still notices)
+#
+# Determinism: stdout is a single JSON line, no trailing whitespace, so
+# fixtures can byte-equal compare without `jq` round-tripping.
+
+set -u
+
+target="${1:-}"
+if [ -z "$target" ]; then
+  echo "usage: h1-modal-helper.sh <file-or-url>" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OPENER="$SCRIPT_DIR/open-browser.sh"
+
+if [ ! -x "$OPENER" ] && [ ! -r "$OPENER" ]; then
+  echo "h1-modal-helper.sh: open-browser.sh not found at $OPENER" >&2
+  exit 1
+fi
+
+# Run opener; capture exit. We deliberately DROP its stdout/stderr
+# because open-browser.sh writes diagnostics on the no-opener path
+# that would otherwise pollute our JSON line. Callers that need the
+# original stderr can run open-browser.sh themselves.
+rc=0
+bash "$OPENER" "$target" >/dev/null 2>&1 || rc=$?
+
+# JSON-encode the URL via python so embedded quotes / backslashes /
+# unicode don't break the consumer's JSON parser. open-browser.sh's
+# S-2 gate already forbids the dangerous characters but defense in
+# depth is cheap here.
+# Fail-closed: if python3 is missing or fails we MUST NOT emit the
+# success-shaped JSON (e.g. `{"mode":"inline","url":}`) that downstream
+# parsers would happily accept. Codex review caught this — invalid
+# JSON breaks the machine-readable contract.
+url_json=$(python3 -c 'import json,sys; sys.stdout.write(json.dumps(sys.argv[1]))' "$target") || {
+  echo "h1-modal-helper.sh: python3 unavailable — cannot encode URL as JSON" >&2
+  exit 1
+}
+
+case "$rc" in
+  0)
+    printf '{"mode":"browser","url":%s}\n' "$url_json"
+    exit 0
+    ;;
+  3)
+    printf '{"mode":"inline","url":%s}\n' "$url_json"
+    exit 0
+    ;;
+  *)
+    printf '{"mode":"error","exit_code":%d,"url":%s}\n' "$rc" "$url_json"
+    exit "$rc"
+    ;;
+esac

--- a/tests/fixtures/filled-ratio-gating/case-high-0.78.json
+++ b/tests/fixtures/filled-ratio-gating/case-high-0.78.json
@@ -1,0 +1,21 @@
+{
+  "_schema_version": "1.0.0",
+  "_filled_ratio": 0.7778,
+  "idea_summary": "High-tier fixture — 7 of 9 slots populated (idea_summary + 3 nested objects + 2 leaf strings + 1 array; non_goals + 1 leaf intentionally left blank). Expected ratio = 7/9 = 0.7778, mapping to mode=ground-truth under A-4.",
+  "target_persona": {
+    "role": "independent paralegal",
+    "context": "depositions for solo-practice attorneys"
+  },
+  "primary_surface": {
+    "kind": "web",
+    "offline_capable": false
+  },
+  "jobs_to_be_done": {
+    "primary": "Index deposition transcripts in under 5 minutes per hour of audio"
+  },
+  "killer_feature": "Speaker-diarized search with citation-ready timestamps",
+  "monetization_model": "per-seat SaaS",
+  "success_metric": null,
+  "must_have_constraints": ["WCAG AA contrast", "no third-party LLM in the audio path"],
+  "non_goals": []
+}

--- a/tests/fixtures/filled-ratio-gating/case-low-0.11.json
+++ b/tests/fixtures/filled-ratio-gating/case-low-0.11.json
@@ -1,0 +1,13 @@
+{
+  "_schema_version": "1.0.0",
+  "_filled_ratio": 0.1111,
+  "idea_summary": "B-3 'Skip interview' fixture — only the required idea_summary is populated, every nested object is null/'unknown', every leaf is null, every array is empty. Expected ratio = 1/9 = 0.1111, mapping to mode=fallback-omit-spec under A-4.",
+  "target_persona": null,
+  "primary_surface": null,
+  "jobs_to_be_done": null,
+  "killer_feature": null,
+  "monetization_model": null,
+  "success_metric": null,
+  "must_have_constraints": [],
+  "non_goals": []
+}

--- a/tests/fixtures/filled-ratio-gating/case-lowconf-0.22.json
+++ b/tests/fixtures/filled-ratio-gating/case-lowconf-0.22.json
@@ -1,0 +1,13 @@
+{
+  "_schema_version": "1.0.0",
+  "_filled_ratio": 0.2222,
+  "idea_summary": "Low-confidence-tier fixture — 2 of 9 slots populated (idea_summary + must_have_constraints array). Expected ratio = 2/9 = 0.2222, mapping to mode=low-confidence under A-4 (0.2 ≤ ratio < 0.4 boundary).",
+  "target_persona": null,
+  "primary_surface": null,
+  "jobs_to_be_done": null,
+  "killer_feature": null,
+  "monetization_model": null,
+  "success_metric": null,
+  "must_have_constraints": ["WCAG AA contrast"],
+  "non_goals": []
+}

--- a/tests/fixtures/filled-ratio-gating/case-mid-0.44.json
+++ b/tests/fixtures/filled-ratio-gating/case-mid-0.44.json
@@ -1,0 +1,19 @@
+{
+  "_schema_version": "1.0.0",
+  "_filled_ratio": 0.4444,
+  "idea_summary": "Mid-tier fixture — 4 of 9 slots populated (idea_summary + target_persona nested + primary_surface nested + must_have_constraints array). Expected ratio = 4/9 = 0.4444, mapping to mode=hint under A-4.",
+  "target_persona": {
+    "role": "indie operator",
+    "context": "running a one-person workshop"
+  },
+  "primary_surface": {
+    "kind": "web",
+    "offline_capable": false
+  },
+  "jobs_to_be_done": null,
+  "killer_feature": null,
+  "monetization_model": null,
+  "success_metric": null,
+  "must_have_constraints": ["mobile-first responsive layout"],
+  "non_goals": []
+}

--- a/tests/fixtures/filled-ratio-gating/verify.sh
+++ b/tests/fixtures/filled-ratio-gating/verify.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# A-4 enforcement fixture — `scripts/filled-ratio-gate.sh`.
+#
+# For four pre-computed `idea.spec.json` cases — one per tier of the
+# A-4 cascade — assert FULL byte-equal stdout for both the default and
+# the `--prompt-fragment` mode. The four-tier byte-stable behavior is
+# the contract; substring matching would not catch a wording drift in
+# the splice fragment, so we compare the entire stdout against an
+# inlined expected blob.
+#
+# Cases:
+#   case-low-0.11.json     ratio=0.1111  mode=fallback-omit-spec
+#   case-lowconf-0.22.json ratio=0.2222  mode=low-confidence
+#   case-mid-0.44.json     ratio=0.4444  mode=hint
+#   case-high-0.78.json    ratio=0.7778  mode=ground-truth
+#
+# Exit 0 = all assertions pass. Exit 1 = at least one mismatch.
+
+set -uo pipefail
+
+FIXTURES_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$FIXTURES_DIR/../../.." && pwd)"
+GATE="$REPO_ROOT/scripts/filled-ratio-gate.sh"
+
+if [[ ! -r "$GATE" ]]; then
+  echo "x filled-ratio-gate.sh not found at $GATE" >&2
+  exit 1
+fi
+
+echo "=== A-4 filled-ratio-gate verify ==="
+echo
+
+fails=0
+
+# --- Default-output (ratio=...\nmode=...) byte-equal compares ---
+assert_default() {
+  local label="$1" path="$2" expected="$3"
+  local actual rc
+  if ! actual=$(bash "$GATE" "$path"); then
+    rc=$?
+    echo "  FAIL [$label] gate exited $rc"
+    fails=$((fails + 1))
+    return
+  fi
+  if [[ "$actual" != "$expected" ]]; then
+    echo "  FAIL [$label] default-mode stdout mismatch"
+    echo "      expected: $(printf '%q' "$expected")"
+    echo "      actual  : $(printf '%q' "$actual")"
+    fails=$((fails + 1))
+    return
+  fi
+  echo "  OK   [$label] default-mode byte-equal"
+}
+
+# --- Prompt-fragment byte-equal compares ---
+assert_fragment() {
+  local label="$1" path="$2" expected="$3"
+  local actual rc
+  if ! actual=$(bash "$GATE" --prompt-fragment "$path"); then
+    rc=$?
+    echo "  FAIL [$label] gate (--prompt-fragment) exited $rc"
+    fails=$((fails + 1))
+    return
+  fi
+  if [[ "$actual" != "$expected" ]]; then
+    echo "  FAIL [$label] fragment stdout mismatch"
+    echo "      expected: $(printf '%q' "$expected")"
+    echo "      actual  : $(printf '%q' "$actual")"
+    fails=$((fails + 1))
+    return
+  fi
+  echo "  OK   [$label] fragment byte-equal"
+}
+
+# Tier 1 — fallback (ratio < 0.2). Note the FRAGMENT_FALLBACK
+# intentionally OMITS the IDEA_SPEC_CONFIDENCE line — that's the
+# heart of the A-4 contract: under-filled specs do not leak partial
+# data into the advocate prompt.
+DEFAULT_LOW=$'ratio=0.1111\nmode=fallback-omit-spec'
+FRAGMENT_LOW='IDEA_SPEC: <not provided — fallback v1.5.4 path>'
+
+# Tier 2 — low-confidence (0.2 ≤ ratio < 0.4).
+DEFAULT_LOWCONF=$'ratio=0.2222\nmode=low-confidence'
+FRAGMENT_LOWCONF=$'IDEA_SPEC_CONFIDENCE: low\nIDEA_SPEC: <splice runs/<id>/idea.spec.json — weak hint, large divergence allowed>'
+
+# Tier 3 — hint (0.4 ≤ ratio < 0.7).
+DEFAULT_MID=$'ratio=0.4444\nmode=hint'
+FRAGMENT_MID=$'IDEA_SPEC_CONFIDENCE: medium\nIDEA_SPEC: <splice runs/<id>/idea.spec.json — hint, free-interpret null/"unknown" fields>'
+
+# Tier 4 — ground-truth (ratio ≥ 0.7).
+DEFAULT_HIGH=$'ratio=0.7778\nmode=ground-truth'
+FRAGMENT_HIGH=$'IDEA_SPEC_CONFIDENCE: high\nIDEA_SPEC: <splice runs/<id>/idea.spec.json verbatim — ground truth>'
+
+assert_default  "low/fallback"      "$FIXTURES_DIR/case-low-0.11.json"     "$DEFAULT_LOW"
+assert_fragment "low/fallback-frag" "$FIXTURES_DIR/case-low-0.11.json"     "$FRAGMENT_LOW"
+
+assert_default  "lowconf"            "$FIXTURES_DIR/case-lowconf-0.22.json" "$DEFAULT_LOWCONF"
+assert_fragment "lowconf-frag"       "$FIXTURES_DIR/case-lowconf-0.22.json" "$FRAGMENT_LOWCONF"
+
+assert_default  "mid/hint"           "$FIXTURES_DIR/case-mid-0.44.json"     "$DEFAULT_MID"
+assert_fragment "mid/hint-frag"      "$FIXTURES_DIR/case-mid-0.44.json"     "$FRAGMENT_MID"
+
+assert_default  "high/ground-truth"      "$FIXTURES_DIR/case-high-0.78.json" "$DEFAULT_HIGH"
+assert_fragment "high/ground-truth-frag" "$FIXTURES_DIR/case-high-0.78.json" "$FRAGMENT_HIGH"
+
+# Defense-in-depth: fallback fragment MUST NOT contain the confidence
+# label at all — even a stray substring would re-introduce the v1.5.4
+# regression A-4 was written to prevent.
+fallback_frag=$(bash "$GATE" --prompt-fragment "$FIXTURES_DIR/case-low-0.11.json")
+if printf '%s' "$fallback_frag" | grep -qF "IDEA_SPEC_CONFIDENCE"; then
+  echo "  FAIL [low/no-conf-leak] fallback fragment leaked IDEA_SPEC_CONFIDENCE"
+  fails=$((fails + 1))
+else
+  echo "  OK   [low/no-conf-leak] fallback fragment correctly omits confidence label"
+fi
+
+echo
+if [[ $fails -eq 0 ]]; then
+  echo "OK A-4 filled-ratio-gate — all assertions pass."
+  exit 0
+fi
+echo "x A-4 filled-ratio-gate — $fails assertion(s) failed."
+exit 1

--- a/tests/fixtures/h1-modal-swap/verify.sh
+++ b/tests/fixtures/h1-modal-swap/verify.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# A-5 enforcement fixture — `scripts/h1-modal-helper.sh`.
+#
+# Two scenarios:
+#   1. NEGATIVE / no-opener: PATH is stripped to a fake bin that has
+#      python3, dirname, basename (so open-browser.sh can run), but NO
+#      `open`, NO `xdg-open`, NO `powershell.exe`, NO `pwsh`. The
+#      helper must emit `{"mode":"inline","url":"..."}` and exit 0.
+#   2. POSITIVE / opener-present: PATH adds a `open` shim that exits 0.
+#      The helper must emit `{"mode":"browser","url":"..."}` and exit 0.
+#
+# Both assertions are byte-equal compares — there is no jq round-trip,
+# so the helper's JSON output format is locked at the byte level.
+
+set -uo pipefail
+
+FIXTURES_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$FIXTURES_DIR/../../.." && pwd)"
+HELPER="$REPO_ROOT/scripts/h1-modal-helper.sh"
+OPENER="$REPO_ROOT/scripts/open-browser.sh"
+
+if [[ ! -r "$HELPER" || ! -r "$OPENER" ]]; then
+  echo "x h1-modal-helper.sh / open-browser.sh missing under $REPO_ROOT/scripts" >&2
+  exit 1
+fi
+
+echo "=== A-5 h1-modal-helper verify ==="
+echo
+
+fails=0
+
+# Locate the bare-minimum tools that open-browser.sh needs and that
+# the helper itself uses (python3 for json.dumps, dirname/basename for
+# path resolution when realpath is absent). We resolve them through
+# the *current* PATH and then symlink into our scrubbed bin so the
+# rest of /usr/bin (notably /usr/bin/open) stays out of reach.
+# Tools the helper / open-browser.sh need at runtime, plus `bash` itself
+# (since we invoke the helper through `env -i ... bash "$HELPER"`).
+need_tools=(bash dirname basename realpath)
+fake_bin=$(mktemp -d -t pf-h1-fake-bin-XXXX)
+trap 'rm -rf "$fake_bin"' EXIT
+
+for t in "${need_tools[@]}"; do
+  src=$(command -v "$t" 2>/dev/null || true)
+  if [[ -z "$src" ]]; then
+    # `realpath` is optional on macOS without coreutils; open-browser.sh
+    # falls back to a shell-native resolution. Skip silently in that case.
+    if [[ "$t" == "realpath" ]]; then
+      continue
+    fi
+    echo "x required tool '$t' not on PATH — cannot build fake bin" >&2
+    exit 1
+  fi
+  ln -sf "$src" "$fake_bin/$t"
+done
+
+# Resolve the *real* python3 interpreter (not a pyenv shim, which would
+# need its own auxiliary tools — awk, head, cut, grep, sed, tr — on the
+# scrubbed PATH and would still fail if pyenv's selected version isn't
+# installed). `sys.executable` of the currently-running interpreter is
+# the canonical absolute path.
+real_py3=$(python3 -c 'import sys; print(sys.executable)')
+if [[ -z "$real_py3" || ! -x "$real_py3" ]]; then
+  echo "x could not resolve real python3 interpreter (got '$real_py3')" >&2
+  exit 1
+fi
+ln -sf "$real_py3" "$fake_bin/python3"
+
+# Sanity: confirm `open` is NOT reachable through the scrubbed PATH.
+if env -i PATH="$fake_bin" command -v open >/dev/null 2>&1; then
+  echo "x scrubbed PATH still resolves 'open' — fixture would not actually exercise the no-opener branch" >&2
+  exit 1
+fi
+
+# A URL the S-2 gate accepts (no shell metacharacters, https scheme).
+test_url="https://example.com/runs/r-2026apr25-test/mockups/gallery.html"
+
+# --- Scenario 1: no opener → mode=inline ---
+expected_inline='{"mode":"inline","url":"https://example.com/runs/r-2026apr25-test/mockups/gallery.html"}'
+inline_rc=0
+inline_out=$(env -i HOME="$HOME" PATH="$fake_bin" bash "$HELPER" "$test_url") || inline_rc=$?
+if [[ "$inline_rc" -ne 0 ]]; then
+  echo "  FAIL [no-opener] helper exit=$inline_rc (expected 0)"
+  fails=$((fails + 1))
+elif [[ "$inline_out" != "$expected_inline" ]]; then
+  echo "  FAIL [no-opener] stdout mismatch"
+  echo "      expected: $expected_inline"
+  echo "      actual  : $inline_out"
+  fails=$((fails + 1))
+else
+  echo "  OK   [no-opener] mode=inline, exit=0, byte-equal"
+fi
+
+# --- Scenario 2: fake `open` shim → mode=browser ---
+shim="$fake_bin/open"
+cat > "$shim" <<'SHIM'
+#!/bin/sh
+# Minimal `open` stub — accept the URL and exit 0 without doing anything.
+exit 0
+SHIM
+chmod +x "$shim"
+
+expected_browser='{"mode":"browser","url":"https://example.com/runs/r-2026apr25-test/mockups/gallery.html"}'
+browser_rc=0
+browser_out=$(env -i HOME="$HOME" PATH="$fake_bin" bash "$HELPER" "$test_url") || browser_rc=$?
+if [[ "$browser_rc" -ne 0 ]]; then
+  echo "  FAIL [opener-present] helper exit=$browser_rc (expected 0)"
+  fails=$((fails + 1))
+elif [[ "$browser_out" != "$expected_browser" ]]; then
+  echo "  FAIL [opener-present] stdout mismatch"
+  echo "      expected: $expected_browser"
+  echo "      actual  : $browser_out"
+  fails=$((fails + 1))
+else
+  echo "  OK   [opener-present] mode=browser, exit=0, byte-equal"
+fi
+
+echo
+if [[ $fails -eq 0 ]]; then
+  echo "OK A-5 h1-modal-helper — all assertions pass."
+  exit 0
+fi
+echo "x A-5 h1-modal-helper — $fails assertion(s) failed."
+exit 1

--- a/tests/fixtures/h1-modal-swap/verify.sh
+++ b/tests/fixtures/h1-modal-swap/verify.sh
@@ -37,7 +37,7 @@ fails=0
 # Tools the helper / open-browser.sh need at runtime, plus `bash` itself
 # (since we invoke the helper through `env -i ... bash "$HELPER"`).
 need_tools=(bash dirname basename realpath)
-fake_bin=$(mktemp -d -t pf-h1-fake-bin-XXXX)
+fake_bin=$(mktemp -d -t pf-h1-fake-bin-XXXXXX)
 trap 'rm -rf "$fake_bin"' EXIT
 
 for t in "${need_tools[@]}"; do


### PR DESCRIPTION
## Summary

Closes the A-4 and A-5 sub-tasks of architectural-enforcement issue #59. A-6 (framework_convergence lint) is W2.8 territory and is **not** in scope here.

- **A-4** — `_filled_ratio` 4-tier cascade was a markdown-only contract in `agents/ideation/ideation-lead.md`. New `scripts/filled-ratio-gate.sh` wraps the canonical `compute-filled-ratio.py` and emits `mode=ground-truth|hint|low-confidence|fallback-omit-spec` (plus a `--prompt-fragment` flag for direct splicing into advocate prompts). I_LEAD now has a script-enforced gate.
- **A-5** — Gate H1 option-④ swap was bullet-points only in `agents/meta/chief-engineer-pm.md`. New `scripts/h1-modal-helper.sh` wraps `open-browser.sh` and emits a deterministic single-line JSON `{"mode":"browser|inline|error",...}` so the swap rule is no longer prose-trust.
- Both helpers fail-closed if `python3` is missing (codex review caught silent-success bugs in the initial draft).

## Files

| Kind | Path |
|---|---|
| new | `scripts/filled-ratio-gate.sh` |
| new | `scripts/h1-modal-helper.sh` |
| new | `tests/fixtures/filled-ratio-gating/{case-low-0.11,case-lowconf-0.22,case-mid-0.44,case-high-0.78}.json` + `verify.sh` |
| new | `tests/fixtures/h1-modal-swap/verify.sh` |
| edit | `plugins/preview-forge/agents/ideation/ideation-lead.md` (A-4 enforcement subsection) |
| edit | `plugins/preview-forge/agents/meta/chief-engineer-pm.md` (delimited A-5 block — `<!-- A-5 enforcement section -->` markers so future W2.8 C-5 edits stay merge-clean) |
| edit | `.github/workflows/ci.yml` (two new fixture invocations) |

## Test plan

- [x] `bash tests/fixtures/filled-ratio-gating/verify.sh` — all 9 byte-equal assertions pass (4 default-mode + 4 fragment + 1 no-leak)
- [x] `bash tests/fixtures/h1-modal-swap/verify.sh` — both branches (no-opener → inline, fake-shim → browser) pass with byte-equal JSON
- [x] `bash scripts/verify-plugin.sh` — Pass=57, Fail=0
- [ ] CI runs both new fixtures on Linux + macOS (verify in PR checks)

## Codex review

One pass per the umbrella `noble-enchanting-floyd.md` workflow.

- **P1 (3 — applied before push):**
  1. `h1-modal-helper.sh` `python3 -c json.dumps` was unchecked → could emit invalid `{"mode":"inline","url":}` if python3 missing. Fixed with `|| { … exit 1; }`.
  2. `filled-ratio-gate.sh` tier-mapping `python3 - <<PY` was unchecked → could emit empty `mode=`. Fixed with `|| exit 2` plus an empty-string guard.
  3. A-4 fixture skipped the `low-confidence` tier and used substring matching. Added `case-lowconf-0.22.json` (2/9 ratio) and rewrote all assertions to byte-equal full-stdout compares.
- **P2 (2 — deferred):**
  1. ideation-lead.md says the wrapper is "canonical computation" — semantically the wrapper is the canonical *gate*, the python script is the canonical *ratio*. Wording polish.
  2. A-5 fixture does not cover the `mode:"error"` path (S-2 reject etc.). The error path is a passthrough; coverage gap is small.
- **P3:** none.

## Out of scope

- A-6 framework_convergence lint → W2.8.
- Touching advocate `*.md` files → W2.6.
- Touching `agents/ideation/diversity-validator.md` → W2.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)