### PR TITLE
chore(deps): pin Playwright + jsonschema as dev dependencies (#95 / #94 follow-up)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,36 @@ claude --plugin-dir ./plugins/preview-forge
 
 Inside Claude Code, try `/pf:help` to see the 14 commands.
 
+### Python dev setup (optional, for tooling / verify-\* scripts)
+
+Preview Forge is primarily JavaScript / Markdown, but a handful of Python
+scripts and tools ship with the repo (hero screenshot helper, schema
+validators embedded in `verify-*` shell harnesses, hooks under
+`plugins/preview-forge/hooks/`). Two third-party packages are pinned in
+[`requirements-dev.txt`](./requirements-dev.txt):
+
+- **`playwright`** — used by `tools/capture-gallery-hero.py` to regenerate
+  `docs/assets/v1.6-gallery-hero.png` (#67 / #94).
+- **`jsonschema`** — used by `scripts/verify-plugin.sh`,
+  `tests/fixtures/security/verify-security.sh`,
+  `tests/fixtures/seed-expectations/verify-seed-expectations.sh`, and
+  `tests/e2e/mock-bootstrap.sh` for schema validation.
+
+Install (once, ideally in a venv):
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate   # optional but recommended
+python3 -m pip install -r requirements-dev.txt
+
+# Only if you need to regenerate the hero screenshot:
+python3 -m playwright install --with-deps firefox chromium
+```
+
+The repo is **not** a Python package — there is no `pyproject.toml` /
+`setup.py`. `requirements-dev.txt` documents the contract; nothing is
+installed by `bash scripts/verify-plugin.sh` itself (it degrades gracefully
+when `jsonschema` is missing, except in CI where it is fail-closed).
+
 ## Contribution types
 
 ### 1. 📚 LESSON (most welcome)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,30 @@
+# Dev-only Python dependencies for Preview Forge tooling.
+#
+# Install:
+#   python3 -m pip install -r requirements-dev.txt
+#
+# Browser binaries for Playwright (one-off, after the pip install above):
+#   python3 -m playwright install --with-deps firefox chromium
+#
+# Preview Forge is NOT a Python package (no installable source / __init__.py).
+# These pins exist so the handful of Python *scripts* and *tools* that the
+# repo ships are reproducible without ambient pip state. JS-side tooling
+# stays in package.json / pnpm-workspace.yaml.
+
+# ---------------------------------------------------------------------------
+# Hero screenshot helper
+#   tools/capture-gallery-hero.py — regenerates docs/assets/v1.6-gallery-hero.png
+#   (the README/SUBMISSION above-the-fold gallery hero, #67 / #94).
+# ---------------------------------------------------------------------------
+playwright>=1.54,<2.0
+
+# ---------------------------------------------------------------------------
+# JSON Schema validation (used by several verify-* shell harnesses that
+# embed `python3 -c "import jsonschema; ..."`):
+#   - scripts/verify-plugin.sh                       (profiles schema check)
+#   - tests/fixtures/security/verify-security.sh     (I-7 / S-3 defenses)
+#   - tests/fixtures/seed-expectations/verify-seed-expectations.sh
+#   - tests/e2e/mock-bootstrap.sh                    (previews schema, fail-closed in CI)
+#   - scripts/generate-spec-anchor-audit.py          (optional; degrades gracefully)
+# ---------------------------------------------------------------------------
+jsonschema>=4.0,<5.0

--- a/tools/capture-gallery-hero.py
+++ b/tools/capture-gallery-hero.py
@@ -16,6 +16,15 @@ the "lots of tiles side-by-side" wow factor in a normal banner ratio.
 
 Determinism: fonts loaded, animations disabled, viewport pinned, file://
 URI. Re-running on the same gallery.html produces a byte-stable PNG.
+
+Setup (#95 / #94 follow-up — Playwright is now a pinned dev dependency):
+
+    python3 -m pip install -r requirements-dev.txt
+    python3 -m playwright install --with-deps firefox chromium
+
+See requirements-dev.txt and CONTRIBUTING.md ("Python dev setup") for the
+full contract. Previously this script relied on an ambient `playwright`
+install; the pin makes it reproducible on a fresh clone.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Closes the **Dev tooling pinning** cluster from #95 (1 item deferred from #94).

- Adds `requirements-dev.txt` pinning the two third-party Python packages the repo's tooling actually imports:
  - `playwright>=1.54,<2.0` — used by `tools/capture-gallery-hero.py` to regen `docs/assets/v1.6-gallery-hero.png` (#67 / #94).
  - `jsonschema>=4.0,<5.0` — used by `verify-plugin.sh`, `verify-security.sh`, `verify-seed-expectations.sh`, `mock-bootstrap.sh`, and `generate-spec-anchor-audit.py`.
- Adds a "Python dev setup" subsection to `CONTRIBUTING.md` explaining install (incl. optional `playwright install --with-deps firefox chromium`).
- Updates `tools/capture-gallery-hero.py` docstring to reference the new install contract.

## File-format choice

Picked **`requirements-dev.txt`** over `pyproject.toml`:

- The repo is **not** a Python package — no installable source, no `__init__.py`, no entry points.
- Python files are scripts/hooks/tools invoked by shell harnesses (`bash scripts/verify-plugin.sh`, `bash tests/e2e/mock-bootstrap.sh`).
- Plain text is the lowest-overhead contract that matches the script-driven nature without forcing a package layout.
- JS-side tooling stays in `package.json` / `pnpm-workspace.yaml` (unchanged).

## Side-effect / breaking-change assessment

| Side-effect | Status | Verification |
|---|---|---|
| `pip install -r requirements-dev.txt` on fresh clone | OK | Verified in fresh `python3 -m venv /tmp/pf-i95-venv` — installs cleanly; `import playwright, jsonschema` both succeed. |
| `tools/capture-gallery-hero.py` after the pin | No behavior change | Already worked locally pre-pin; pin only documents the contract. Did NOT regenerate the PNG (per task scope). |
| `bash scripts/verify-plugin.sh` | OK | Pass: 57 / Fail: 0. |
| `bash tests/fixtures/security/verify-security.sh` | OK | All Phase 1 defenses holding (#95-L1, L1-wire, L3, S-5, S-6, I-9). |
| `bash tests/e2e/mock-bootstrap.sh {standard,pro,max}` | OK | PASS x3, schemas valid, iframe counts 9/18/26 as expected. |
| CI workflows | No change required | CI didn't get a `pip install -r requirements-dev.txt` step in this PR — current CI already installs `jsonschema` ambiently (or scripts degrade gracefully); changing CI is out of scope. P3 below. |
| macOS vs Linux | OK | `playwright>=1.54` works on both; jsonschema is pure-Python. |
| Pre-existing pyenv/venv collision | None | `pip install` is additive; no system-level changes. |
| Breaking change | None | New file + docstring + docs section; no removals or behavior change. |

## Codex review (1 pass)

- **P1 applied**: 0 (codex returned no P1 findings)
- **P2 deferred to follow-up**: 1
- **P3 deferred**: 1

### P2 — pin exact versions (deferred)

Codex flagged `playwright>=1.54,<2.0` / `jsonschema>=4.0,<5.0` as **ranges, not exact pins**, arguing reproducibility could drift across new Playwright 1.x releases (browser revisions ship with the package). Counter-arguments for keeping the ranges in this PR:

1. The byte-stable PNG promise in `capture-gallery-hero.py` is "same Playwright + same gallery.html → same PNG", not "stable across Playwright upgrades". The pin does not regress that contract.
2. Exact pins (`playwright==1.54.0`) would force lockstep upgrades across contributors and require a `requirements-dev.lock` workflow, which is out of scope for a 30-min PR.
3. We do not currently pin browser binaries either (`playwright install` resolves to whatever's bundled), so an exact pip pin would be a half-measure without `playwright install --version`.

Suggested follow-up: introduce `pip-tools` / `uv pip compile` and a `requirements-dev.lock` if/when the hero PNG drifts.

### P3 — CI integration (deferred)

Add `python3 -m pip install -r requirements-dev.txt` to `.github/workflows/ci.yml` before any Python-using job. Current CI works because GitHub-hosted runners ship `jsonschema` (or scripts no-op). Worth doing for explicit-contract reasons but not required to land this PR.

## Test plan

- [x] `python3 -m venv /tmp/pf-i95-venv && /tmp/pf-i95-venv/bin/pip install -r requirements-dev.txt` succeeds
- [x] `bash scripts/verify-plugin.sh` — Pass: 57 / Fail: 0
- [x] `bash tests/fixtures/security/verify-security.sh` — all defenses holding
- [x] `bash tests/e2e/mock-bootstrap.sh standard` — PASS
- [x] `bash tests/e2e/mock-bootstrap.sh pro` — PASS
- [x] `bash tests/e2e/mock-bootstrap.sh max` — PASS
- [ ] CI green on PR

## Refs

- Closes the Playwright-pinning item in #95
- Follow-up to #94 (gallery-first README hero)