### PR TITLE
feat(workflow): H2→preview server auto-launch + /pf:preview slash command (Phase 2)

### DIFF
--- a/plugins/preview-forge/agents/meta/chief-engineer-pm.md
+++ b/plugins/preview-forge/agents/meta/chief-engineer-pm.md
@@ -128,6 +128,23 @@ Task({
 이 dispatch는 markdown 지시가 아니라 **명령형 imperative** — LLM trust 줄이기 위해 의도적으로 명시적 Task block.
 <!-- end H1→SpecDD auto-advance -->
 
+<!-- H2→preview-server auto-launch (PR Phase 2, addresses user-reported gap) -->
+#### H2 승인 후 즉시 preview 서버 자동 기동 (자동, 사용자 입력 없음)
+
+`/pf:export` (또는 사용자가 H2에서 deploy 승인) 후, M3는 **즉시** preview 서버를 기동한다. README의 "human clicks twice" 약속에 따라 H2 외에는 자동 진행.
+
+검증 스크립트 (Phase 1과 동일한 plugin-root 절대 경로 형태 — 사용자 workspace에서 `scripts/`가 없어도 동작):
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/../../scripts/start-preview-server.sh" runs/<id>/
+# exit 0 → 서버 기동 + 브라우저 자동 오픈
+# exit 2 → scaffold 누락 (TestDD freeze 미완료); 사용자에게 보고
+```
+
+수동 재실행 / 정지: `/pf:preview <id>` / `/pf:preview stop <id>`.
+
+Idempotent: 이미 살아있는 서버에 대해서는 URL만 다시 열기, 재기동 안 함.
+<!-- end H2→preview-server auto-launch -->
+
 ### 4. Memory 파일 관리 (쓰기 권한 독점)
 
 **Rule 3**에 따라 당신만 `memory/{CLAUDE,PROGRESS,LESSONS}.md`에 쓸 수 있습니다. 다른 agent는 Blackboard에 `memory.request.{file}` 키로 요청 → 당신이 검토 후 batch 반영.

--- a/plugins/preview-forge/agents/meta/chief-engineer-pm.md
+++ b/plugins/preview-forge/agents/meta/chief-engineer-pm.md
@@ -196,9 +196,10 @@ Auto-retro-trigger 훅이 Blackboard에 `retro.requested` 행을 기록하면:
   - `runs/<id>/design-approved.json` (Gate H1 수집 결과)
   - `/memories/m3-decisions/*.md` (자신의 reflection)
 - Task: 모든 department lead 호출 가능
-- Bash: **H1/H2 gate 지원용 read-only scripts만** 허용 (v1.6.0+). 구체적으로:
-  - `scripts/generate-gallery.sh <run-dir>` (H1 gallery HTML 생성)
-  - `scripts/open-browser.sh <path-or-url>` (H1 gallery auto-open, 비블로킹)
+- Bash: **H1/H2 gate 지원용 scripts만** 허용 (v1.6.0+). 구체적으로:
+  - `scripts/generate-gallery.sh <run-dir>` (H1 gallery HTML 생성, read-only)
+  - `scripts/open-browser.sh <path-or-url>` (H1 gallery auto-open, 비블로킹, read-only)
+  - `scripts/start-preview-server.sh <run-dir>` 및 `start|stop|status` 형태 (v1.7.0+ Phase 2 sanctioned exception: stateful이지만 idempotent + run_dir-local 작용으로 한정 — H2 finalize 직후 single-shot으로만 호출. PID/URL/log 파일은 모두 `<run_dir>/.preview-*`에만 기록되며, factory-policy/Rule 6 enforcement에서 명시적으로 화이트리스트 처리됨.)
   - 그 외 destructive·stateful Bash는 차단 (Rule 6). 상태 변화는 Write 또는 sub-agent 위임.
 
 ## forbidden

--- a/plugins/preview-forge/commands/freeze.md
+++ b/plugins/preview-forge/commands/freeze.md
@@ -20,6 +20,10 @@ description: Force evaluate Judges + Auditors and attempt freeze
 
 현재 run의 Stage 7 (Judges + Auditors)를 강제 실행. 점수 미달이면 dissent와 함께 보고만 하고 freeze 안 함.
 
+## After freeze
+
+Once `score/report.json` is locked and `.frozen-hash` written, M3 automatically launches the local preview server (`bash scripts/start-preview-server.sh runs/<id>/`) and opens your browser to the running app. To re-open or stop the server later: `/pf:preview <id>` / `/pf:preview stop <id>`.
+
 ## 관련
 
 - 본 명령은 plugin `preview-forge`의 일부입니다.

--- a/plugins/preview-forge/commands/preview.md
+++ b/plugins/preview-forge/commands/preview.md
@@ -1,0 +1,45 @@
+---
+description: Launch the local preview server for a frozen run (post-H2 or manual re-open)
+---
+
+# /pf:preview — Launch the local preview server for a frozen run
+
+**Layer-0 정책**: Pro/Max 기본 포함. 별도 API 키 불필요.
+
+## Usage
+
+```
+/pf:preview [run_id]
+/pf:preview stop [run_id]
+/pf:preview status [run_id]
+```
+
+## 인자
+
+- `run_id` (optional): 특정 run. 생략 시 가장 최근 run (`ls -t runs/r-* | head -1`).
+
+## 동작
+
+`bash scripts/start-preview-server.sh runs/<id>/` 호출. `runs/<id>/` 의 내용으로 profile 자동 감지:
+
+1. `docker-compose.yml` 존재 (pro/max) → `docker compose up -d` + 첫 published port → 브라우저 자동 오픈.
+2. `apps/api/package.json` + `apps/web/package.json` 존재 (standard) → 의존성 설치 → 18080부터 free port 자동 탐색 → `pnpm dev` 백그라운드 spawn → web TCP accept 대기 (≤60s) → 브라우저 자동 오픈.
+3. 둘 다 없음 → exit 2 (TestDD freeze 미완료).
+
+본 명령은 H2 승인 직후 M3가 자동으로 한 번 호출하므로 수동 실행은 보통 **재오픈** 또는 **재기동** 용도다 (서버를 stop 했거나 머신을 재부팅한 경우).
+
+## Idempotency
+
+이미 살아있는 PID 가 `<run_dir>/.preview-server.pid` 에 있으면 재기동 없이 URL 만 다시 연다. 두 번 spawn 되지 않는다.
+
+## 종료
+
+- `/pf:preview stop <run_id>` — SIGTERM → 5s 대기 → SIGKILL fallback. docker 프로필은 `docker compose down`.
+- `/pf:preview status <run_id>` — 살아있으면 stdout 에 URL + exit 0, 아니면 exit 1.
+
+## 관련
+
+- 본 명령은 plugin `preview-forge`의 일부입니다.
+- 스크립트: `scripts/start-preview-server.sh` (CI 테스트용 `PF_PREVIEW_DRY_RUN=1` 지원).
+- Gap B 배경: DEMO-STORYBOARD.md L1:50–2:00 의 자동 localhost:18080 약속.
+- 상세 스펙: [preview-forge-proposal.html](../../../preview-forge-proposal.html)

--- a/scripts/start-preview-server.sh
+++ b/scripts/start-preview-server.sh
@@ -8,12 +8,14 @@
 # DEMO-STORYBOARD.md L1:50–2:00 expectation that a new tab pops up at
 # http://localhost:18080 automatically.
 #
-# Profiles auto-detected from <run_dir> contents:
-#   1. pro / max     — `<run_dir>/docker-compose.yml` exists.
+# Profiles auto-detected from <run_dir> contents (also probes <run_dir>/generated/
+# since be-lead.md and the QA leads write apps to runs/<id>/generated/, while
+# /pf:freeze and /pf:preview pass `runs/<id>/`):
+#   1. pro / max     — docker-compose.yml at run_dir/ or run_dir/generated/.
 #                      → `docker compose up -d`, wait for any service Up,
 #                        extract first published port, open browser.
-#   2. standard      — `<run_dir>/apps/api/package.json` AND
-#                      `<run_dir>/apps/web/package.json` exist.
+#   2. standard      — apps/api/package.json AND apps/web/package.json at
+#                      run_dir/ or run_dir/generated/.
 #                      → install (pnpm > npm), pick free port from 18080+,
 #                        spawn api + web `pnpm dev` in background, persist
 #                        PIDs, wait for web TCP, open browser.
@@ -108,7 +110,7 @@ pids_alive() {
 
 docker_project_up() {
   [ -f "$ID_FILE" ] || return 1
-  local compose_file="$run_dir/docker-compose.yml"
+  local compose_file="${scaffold_root:-$run_dir}/docker-compose.yml"
   [ -f "$compose_file" ] || return 1
   command -v docker >/dev/null 2>&1 || return 1
   # Any service in `running` state?
@@ -157,12 +159,19 @@ open_url() {
 }
 
 # ---- profile detection ----
+# Engineering teams (be-lead.md) write apps to `runs/<id>/generated/`, but
+# `/pf:freeze` and `/pf:preview` instruct callers to pass `runs/<id>/`. So if
+# the scaffold isn't directly under run_dir, transparently fall through to
+# `<run_dir>/generated/` before declaring "scaffold missing".
+scaffold_root=""
 profile=""
-if [ -f "$run_dir/docker-compose.yml" ]; then
-  profile="docker"
-elif [ -f "$run_dir/apps/api/package.json" ] && [ -f "$run_dir/apps/web/package.json" ]; then
-  profile="standard"
-fi
+for cand in "$run_dir" "$run_dir/generated"; do
+  if [ -f "$cand/docker-compose.yml" ]; then
+    scaffold_root="$cand"; profile="docker"; break
+  elif [ -f "$cand/apps/api/package.json" ] && [ -f "$cand/apps/web/package.json" ]; then
+    scaffold_root="$cand"; profile="standard"; break
+  fi
+done
 
 # ---- action: status ----
 if [ "$action" = "status" ]; then
@@ -207,9 +216,15 @@ if [ "$action" = "stop" ]; then
     fi
     rm -f "$PID_FILE"
   fi
-  # Docker-based stop.
-  if [ -f "$ID_FILE" ] && [ -f "$run_dir/docker-compose.yml" ] && command -v docker >/dev/null 2>&1; then
-    docker compose -f "$run_dir/docker-compose.yml" down >/dev/null 2>&1 || true
+  # Docker-based stop. Scaffold may live under either run_dir or run_dir/generated.
+  stop_compose=""
+  for cand in "$run_dir" "$run_dir/generated"; do
+    if [ -f "$cand/docker-compose.yml" ]; then
+      stop_compose="$cand/docker-compose.yml"; break
+    fi
+  done
+  if [ -f "$ID_FILE" ] && [ -n "$stop_compose" ] && command -v docker >/dev/null 2>&1; then
+    docker compose -f "$stop_compose" down >/dev/null 2>&1 || true
   fi
   rm -f "$ID_FILE" "$URL_FILE"
   echo "preview server stopped (run_dir=$run_dir)"
@@ -220,7 +235,7 @@ fi
 
 # No profile detected → caller has not run TestDD freeze yet.
 if [ -z "$profile" ]; then
-  echo "neither apps/{api,web}/package.json nor docker-compose.yml found in $run_dir; cannot start preview server" >&2
+  echo "neither apps/{api,web}/package.json nor docker-compose.yml found in $run_dir or $run_dir/generated; cannot start preview server" >&2
   exit 2
 fi
 
@@ -252,7 +267,7 @@ fi
 
 # ---- profile: docker (pro / max) ----
 if [ "$profile" = "docker" ]; then
-  compose_file="$run_dir/docker-compose.yml"
+  compose_file="$scaffold_root/docker-compose.yml"
   if [ "${PF_PREVIEW_DRY_RUN:-0}" = "1" ]; then
     echo "[dry-run] profile=docker compose_file=$compose_file"
     echo "[dry-run] would: docker compose -f $compose_file up -d --quiet-pull"
@@ -284,23 +299,24 @@ if [ "$profile" = "docker" ]; then
     port="$(docker compose -f "$compose_file" ps --format json 2>/dev/null \
       | python3 -c '
 import json, sys
-for line in sys.stdin:
-    line = line.strip()
-    if not line:
-        continue
+raw = sys.stdin.read().strip()
+records = []
+if raw:
+    # Older docker emits a single JSON array; newer ones emit NDJSON.
     try:
-        rec = json.loads(line)
+        parsed = json.loads(raw)
+        records = parsed if isinstance(parsed, list) else [parsed]
     except json.JSONDecodeError:
-        # Some docker versions emit a single JSON array instead of NDJSON.
-        try:
-            arr = json.loads(line)
-        except Exception:
-            continue
-        for rec in arr if isinstance(arr, list) else []:
-            for p in rec.get("Publishers") or []:
-                pub = p.get("PublishedPort")
-                if pub:
-                    print(pub); sys.exit(0)
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+for rec in records:
+    if not isinstance(rec, dict):
         continue
     for p in rec.get("Publishers") or []:
         pub = p.get("PublishedPort")
@@ -321,8 +337,8 @@ for line in sys.stdin:
 fi
 
 # ---- profile: standard (apps/api + apps/web) ----
-api_dir="$run_dir/apps/api"
-web_dir="$run_dir/apps/web"
+api_dir="$scaffold_root/apps/api"
+web_dir="$scaffold_root/apps/web"
 
 # Pick free ports: web on 18080+, api on 18180+ (offset of 100 keeps logs scannable).
 web_port="$(pick_free_port 18080 11)" || {
@@ -346,9 +362,9 @@ fi
 
 # Install deps. Prefer pnpm if pnpm-lock.yaml exists; else npm.
 pkg_mgr=""
-if command -v pnpm >/dev/null 2>&1 && [ -f "$run_dir/pnpm-lock.yaml" ]; then
+if command -v pnpm >/dev/null 2>&1 && [ -f "$scaffold_root/pnpm-lock.yaml" ]; then
   pkg_mgr="pnpm"
-elif command -v pnpm >/dev/null 2>&1 && [ -f "$run_dir/pnpm-workspace.yaml" ]; then
+elif command -v pnpm >/dev/null 2>&1 && [ -f "$scaffold_root/pnpm-workspace.yaml" ]; then
   pkg_mgr="pnpm"
 elif command -v npm >/dev/null 2>&1; then
   pkg_mgr="npm"
@@ -358,28 +374,37 @@ else
 fi
 case "$pkg_mgr" in
   pnpm )
-    (cd "$run_dir" && pnpm install --frozen-lockfile >/dev/null 2>&1) || \
-      (cd "$run_dir" && pnpm install >/dev/null 2>&1) || {
-        echo "start-preview-server.sh: pnpm install failed in $run_dir" >&2
+    (cd "$scaffold_root" && pnpm install --frozen-lockfile >/dev/null 2>&1) || \
+      (cd "$scaffold_root" && pnpm install >/dev/null 2>&1) || {
+        echo "start-preview-server.sh: pnpm install failed in $scaffold_root" >&2
         exit 1
       }
     dev_cmd="pnpm dev"
     ;;
   npm )
-    (cd "$run_dir" && npm install >/dev/null 2>&1) || true
+    (cd "$scaffold_root" && npm install >/dev/null 2>&1) || true
     (cd "$api_dir" && npm install >/dev/null 2>&1) || true
     (cd "$web_dir" && npm install >/dev/null 2>&1) || true
     dev_cmd="npm run dev"
     ;;
 esac
 
-# Spawn api + web in background, redirecting output. setsid (if available)
-# detaches them from the controlling tty so they survive shell exit.
-spawn() {
-  local dir="$1" port="$2" log="$3" extra_env="$4"
-  ( cd "$dir" && eval "$extra_env PORT=$port nohup $dev_cmd >'$log' 2>&1 &" echo $! )
+# Cleanup spawned api/web on early exit so a wait_tcp timeout does not leak
+# zombie processes that would still hold the port and force the next retry to
+# pick a higher port (causing PID_FILE drift).
+cleanup_spawned() {
+  local pid
+  for pid in "${api_pid:-}" "${web_pid:-}"; do
+    case "$pid" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+  rm -f "$PID_FILE"
 }
 
+# Spawn api + web in background, redirecting output. nohup detaches them
+# from the controlling tty so they survive shell exit.
 api_pid="$( ( cd "$api_dir" && PORT="$api_port" nohup $dev_cmd >"$API_LOG" 2>&1 & echo $! ) )"
 web_pid="$( ( cd "$web_dir" && PORT="$web_port" NEXT_PUBLIC_API_URL="http://localhost:$api_port" nohup $dev_cmd >"$WEB_LOG" 2>&1 & echo $! ) )"
 
@@ -394,6 +419,7 @@ if ! wait_tcp 127.0.0.1 "$web_port" 60; then
   echo "start-preview-server.sh: web server did not start on :$web_port within 60s" >&2
   echo "  api log: $API_LOG"
   echo "  web log: $WEB_LOG"
+  cleanup_spawned
   exit 1
 fi
 

--- a/scripts/start-preview-server.sh
+++ b/scripts/start-preview-server.sh
@@ -1,0 +1,402 @@
+#!/usr/bin/env bash
+# Preview Forge — Phase 2 (Gap B fix): post-H2 local preview server launcher.
+#
+# Bridges the gap between TestDD freeze (H2 approval) and the user actually
+# seeing the generated app in their browser. Before this script the user had
+# to run `pnpm -r dev` or `docker compose up` manually after every freeze,
+# breaking the README "human clicks twice" promise and the
+# DEMO-STORYBOARD.md L1:50–2:00 expectation that a new tab pops up at
+# http://localhost:18080 automatically.
+#
+# Profiles auto-detected from <run_dir> contents:
+#   1. pro / max     — `<run_dir>/docker-compose.yml` exists.
+#                      → `docker compose up -d`, wait for any service Up,
+#                        extract first published port, open browser.
+#   2. standard      — `<run_dir>/apps/api/package.json` AND
+#                      `<run_dir>/apps/web/package.json` exist.
+#                      → install (pnpm > npm), pick free port from 18080+,
+#                        spawn api + web `pnpm dev` in background, persist
+#                        PIDs, wait for web TCP, open browser.
+#   3. neither       — exit 2 with stderr message (TestDD scaffold incomplete).
+#
+# CLI:
+#   start-preview-server.sh <run_dir>
+#       Idempotent: if PIDs in <run_dir>/.preview-server.pid are alive,
+#       only re-open the browser. Otherwise start fresh.
+#   start-preview-server.sh stop <run_dir>
+#       SIGTERM → wait 5s → SIGKILL. For docker, `docker compose down`.
+#       Removes .preview-server.{pid,id,url}. Idempotent (no-op if no PID).
+#   start-preview-server.sh status <run_dir>
+#       Exit 0 if a preview server is running for <run_dir> (PIDs alive
+#       OR docker project still up), prints URL on stdout.
+#       Exit 1 otherwise.
+#
+# Env flags (test/CI helpers):
+#   PF_PREVIEW_DRY_RUN=1   — print the actions that would happen, then exit
+#                            0. No `pnpm install`, no `docker compose up`,
+#                            no background process spawn, no browser open.
+#                            Used by tests/fixtures/post-h2-preview to keep
+#                            the unit suite light. Profile detection still
+#                            runs; missing-scaffold still exits 2.
+#
+# Style anchors:
+#   - exit-code contract follows scripts/h1-modal-helper.sh
+#   - browser open delegated to scripts/open-browser.sh
+#   - portability: lsof is preinstalled on macOS+Linux; pnpm fallback to
+#     npm; docker check via `command -v`.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OPENER="$SCRIPT_DIR/open-browser.sh"
+
+usage() {
+  cat <<'EOF' >&2
+usage:
+  start-preview-server.sh <run_dir>
+  start-preview-server.sh stop <run_dir>
+  start-preview-server.sh status <run_dir>
+EOF
+  exit 1
+}
+
+# ---- arg parsing ----
+action="start"
+case "${1:-}" in
+  "" )
+    usage
+    ;;
+  stop|status )
+    action="$1"
+    shift
+    ;;
+esac
+
+run_dir="${1:-}"
+[ -n "$run_dir" ] || usage
+# Strip trailing slash for consistent file paths.
+run_dir="${run_dir%/}"
+if [ ! -d "$run_dir" ]; then
+  echo "start-preview-server.sh: run_dir not found: $run_dir" >&2
+  exit 1
+fi
+
+PID_FILE="$run_dir/.preview-server.pid"
+ID_FILE="$run_dir/.preview-server.id"
+URL_FILE="$run_dir/.preview-server.url"
+API_LOG="$run_dir/.preview-api.log"
+WEB_LOG="$run_dir/.preview-web.log"
+
+# ---- helpers ----
+pids_alive() {
+  # Echo each alive PID found in PID_FILE; return 0 if any alive.
+  [ -f "$PID_FILE" ] || return 1
+  local any=1 line pid
+  while IFS= read -r line; do
+    # lines look like "api 12345" or "web 67890" or just "12345"
+    pid="${line##* }"
+    case "$pid" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    if kill -0 "$pid" 2>/dev/null; then
+      echo "$pid"
+      any=0
+    fi
+  done <"$PID_FILE"
+  return "$any"
+}
+
+docker_project_up() {
+  [ -f "$ID_FILE" ] || return 1
+  local compose_file="$run_dir/docker-compose.yml"
+  [ -f "$compose_file" ] || return 1
+  command -v docker >/dev/null 2>&1 || return 1
+  # Any service in `running` state?
+  local running
+  running="$(docker compose -f "$compose_file" ps --status running --quiet 2>/dev/null || true)"
+  [ -n "$running" ]
+}
+
+pick_free_port() {
+  # Print first free TCP port in [start, start+max-1]; exit 1 if none found.
+  local start="$1" max="${2:-11}" p
+  for ((i = 0; i < max; i++)); do
+    p=$((start + i))
+    if command -v lsof >/dev/null 2>&1; then
+      lsof -iTCP:"$p" -sTCP:LISTEN -Pn >/dev/null 2>&1 || { echo "$p"; return 0; }
+    else
+      # Fallback: try /dev/tcp probe (bash-only; cheap).
+      (echo > "/dev/tcp/127.0.0.1/$p") >/dev/null 2>&1 || { echo "$p"; return 0; }
+    fi
+  done
+  return 1
+}
+
+wait_tcp() {
+  # wait_tcp <host> <port> <timeout_sec>
+  local host="$1" port="$2" timeout="$3" t=0
+  while [ "$t" -lt "$timeout" ]; do
+    if command -v nc >/dev/null 2>&1; then
+      nc -z "$host" "$port" >/dev/null 2>&1 && return 0
+    else
+      (echo > "/dev/tcp/$host/$port") >/dev/null 2>&1 && return 0
+    fi
+    sleep 1
+    t=$((t + 1))
+  done
+  return 1
+}
+
+open_url() {
+  local url="$1"
+  if [ -x "$OPENER" ] || [ -r "$OPENER" ]; then
+    bash "$OPENER" "$url" >/dev/null 2>&1 || true
+  fi
+  echo "$url" >"$URL_FILE"
+  echo "preview server up: $url"
+}
+
+# ---- profile detection ----
+profile=""
+if [ -f "$run_dir/docker-compose.yml" ]; then
+  profile="docker"
+elif [ -f "$run_dir/apps/api/package.json" ] && [ -f "$run_dir/apps/web/package.json" ]; then
+  profile="standard"
+fi
+
+# ---- action: status ----
+if [ "$action" = "status" ]; then
+  case "$profile" in
+    standard )
+      if pids_alive >/dev/null; then
+        [ -f "$URL_FILE" ] && cat "$URL_FILE" || echo "running"
+        exit 0
+      fi
+      ;;
+    docker )
+      if docker_project_up; then
+        [ -f "$URL_FILE" ] && cat "$URL_FILE" || echo "running"
+        exit 0
+      fi
+      ;;
+  esac
+  echo "no preview server for $run_dir" >&2
+  exit 1
+fi
+
+# ---- action: stop ----
+if [ "$action" = "stop" ]; then
+  # PID-based stop (standard).
+  if [ -f "$PID_FILE" ]; then
+    while IFS= read -r line; do
+      pid="${line##* }"
+      case "$pid" in ''|*[!0-9]*) continue ;; esac
+      kill -TERM "$pid" 2>/dev/null || true
+    done <"$PID_FILE"
+    # Wait up to 5s for graceful exit.
+    for _ in 1 2 3 4 5; do
+      pids_alive >/dev/null || break
+      sleep 1
+    done
+    if pids_alive >/dev/null; then
+      while IFS= read -r line; do
+        pid="${line##* }"
+        case "$pid" in ''|*[!0-9]*) continue ;; esac
+        kill -KILL "$pid" 2>/dev/null || true
+      done <"$PID_FILE"
+    fi
+    rm -f "$PID_FILE"
+  fi
+  # Docker-based stop.
+  if [ -f "$ID_FILE" ] && [ -f "$run_dir/docker-compose.yml" ] && command -v docker >/dev/null 2>&1; then
+    docker compose -f "$run_dir/docker-compose.yml" down >/dev/null 2>&1 || true
+  fi
+  rm -f "$ID_FILE" "$URL_FILE"
+  echo "preview server stopped (run_dir=$run_dir)"
+  exit 0
+fi
+
+# ---- action: start (default) ----
+
+# No profile detected → caller has not run TestDD freeze yet.
+if [ -z "$profile" ]; then
+  echo "neither apps/{api,web}/package.json nor docker-compose.yml found in $run_dir; cannot start preview server" >&2
+  exit 2
+fi
+
+# Idempotency: if something is already alive, just re-open the URL.
+if [ "$profile" = "standard" ] && pids_alive >/dev/null; then
+  if [ -f "$URL_FILE" ]; then
+    url="$(cat "$URL_FILE")"
+    echo "preview server already running (idempotent re-open)"
+    if [ "${PF_PREVIEW_DRY_RUN:-0}" = "1" ]; then
+      echo "[dry-run] would re-open $url"
+      exit 0
+    fi
+    open_url "$url"
+    exit 0
+  fi
+fi
+if [ "$profile" = "docker" ] && docker_project_up; then
+  if [ -f "$URL_FILE" ]; then
+    url="$(cat "$URL_FILE")"
+    echo "preview server already running (idempotent re-open)"
+    if [ "${PF_PREVIEW_DRY_RUN:-0}" = "1" ]; then
+      echo "[dry-run] would re-open $url"
+      exit 0
+    fi
+    open_url "$url"
+    exit 0
+  fi
+fi
+
+# ---- profile: docker (pro / max) ----
+if [ "$profile" = "docker" ]; then
+  compose_file="$run_dir/docker-compose.yml"
+  if [ "${PF_PREVIEW_DRY_RUN:-0}" = "1" ]; then
+    echo "[dry-run] profile=docker compose_file=$compose_file"
+    echo "[dry-run] would: docker compose -f $compose_file up -d --quiet-pull"
+    echo "[dry-run] would: poll docker compose ps until any service Up (≤30s)"
+    echo "[dry-run] would: extract first published port and open-browser.sh"
+    exit 0
+  fi
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "start-preview-server.sh: docker not on PATH but $compose_file requires it" >&2
+    exit 1
+  fi
+  docker compose -f "$compose_file" up -d --quiet-pull >/dev/null 2>&1 || {
+    echo "start-preview-server.sh: docker compose up failed; see compose logs" >&2
+    exit 1
+  }
+  # Wait up to 30s for at least one service running.
+  t=0
+  while [ "$t" -lt 30 ]; do
+    if [ -n "$(docker compose -f "$compose_file" ps --status running --quiet 2>/dev/null || true)" ]; then
+      break
+    fi
+    sleep 1
+    t=$((t + 1))
+  done
+  # Extract first host port via `docker compose ps --format json`.
+  port=""
+  host="localhost"
+  if command -v python3 >/dev/null 2>&1; then
+    port="$(docker compose -f "$compose_file" ps --format json 2>/dev/null \
+      | python3 -c '
+import json, sys
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        rec = json.loads(line)
+    except json.JSONDecodeError:
+        # Some docker versions emit a single JSON array instead of NDJSON.
+        try:
+            arr = json.loads(line)
+        except Exception:
+            continue
+        for rec in arr if isinstance(arr, list) else []:
+            for p in rec.get("Publishers") or []:
+                pub = p.get("PublishedPort")
+                if pub:
+                    print(pub); sys.exit(0)
+        continue
+    for p in rec.get("Publishers") or []:
+        pub = p.get("PublishedPort")
+        if pub:
+            print(pub); sys.exit(0)
+' || true)"
+  fi
+  if [ -z "$port" ]; then
+    # Fallback: assume Caddy or web service on 18080 per project convention.
+    port="18080"
+  fi
+  # Stash compose project name (basename of run_dir is used by default).
+  project_name="$(basename "$run_dir")"
+  echo "$project_name" >"$ID_FILE"
+  url="http://$host:$port/"
+  open_url "$url"
+  exit 0
+fi
+
+# ---- profile: standard (apps/api + apps/web) ----
+api_dir="$run_dir/apps/api"
+web_dir="$run_dir/apps/web"
+
+# Pick free ports: web on 18080+, api on 18180+ (offset of 100 keeps logs scannable).
+web_port="$(pick_free_port 18080 11)" || {
+  echo "start-preview-server.sh: no free port in 18080..18090" >&2
+  exit 1
+}
+api_port="$(pick_free_port 18180 11)" || {
+  echo "start-preview-server.sh: no free port in 18180..18190" >&2
+  exit 1
+}
+
+if [ "${PF_PREVIEW_DRY_RUN:-0}" = "1" ]; then
+  echo "[dry-run] profile=standard"
+  echo "[dry-run] api_dir=$api_dir api_port=$api_port"
+  echo "[dry-run] web_dir=$web_dir web_port=$web_port"
+  echo "[dry-run] would: install deps (pnpm > npm), spawn api+web in background"
+  echo "[dry-run] would: wait_tcp 127.0.0.1 $web_port 60"
+  echo "[dry-run] would: open http://localhost:$web_port/"
+  exit 0
+fi
+
+# Install deps. Prefer pnpm if pnpm-lock.yaml exists; else npm.
+pkg_mgr=""
+if command -v pnpm >/dev/null 2>&1 && [ -f "$run_dir/pnpm-lock.yaml" ]; then
+  pkg_mgr="pnpm"
+elif command -v pnpm >/dev/null 2>&1 && [ -f "$run_dir/pnpm-workspace.yaml" ]; then
+  pkg_mgr="pnpm"
+elif command -v npm >/dev/null 2>&1; then
+  pkg_mgr="npm"
+else
+  echo "start-preview-server.sh: neither pnpm nor npm available" >&2
+  exit 1
+fi
+case "$pkg_mgr" in
+  pnpm )
+    (cd "$run_dir" && pnpm install --frozen-lockfile >/dev/null 2>&1) || \
+      (cd "$run_dir" && pnpm install >/dev/null 2>&1) || {
+        echo "start-preview-server.sh: pnpm install failed in $run_dir" >&2
+        exit 1
+      }
+    dev_cmd="pnpm dev"
+    ;;
+  npm )
+    (cd "$run_dir" && npm install >/dev/null 2>&1) || true
+    (cd "$api_dir" && npm install >/dev/null 2>&1) || true
+    (cd "$web_dir" && npm install >/dev/null 2>&1) || true
+    dev_cmd="npm run dev"
+    ;;
+esac
+
+# Spawn api + web in background, redirecting output. setsid (if available)
+# detaches them from the controlling tty so they survive shell exit.
+spawn() {
+  local dir="$1" port="$2" log="$3" extra_env="$4"
+  ( cd "$dir" && eval "$extra_env PORT=$port nohup $dev_cmd >'$log' 2>&1 &" echo $! )
+}
+
+api_pid="$( ( cd "$api_dir" && PORT="$api_port" nohup $dev_cmd >"$API_LOG" 2>&1 & echo $! ) )"
+web_pid="$( ( cd "$web_dir" && PORT="$web_port" NEXT_PUBLIC_API_URL="http://localhost:$api_port" nohup $dev_cmd >"$WEB_LOG" 2>&1 & echo $! ) )"
+
+# Persist PIDs (one per line, role-labeled).
+{
+  echo "api $api_pid"
+  echo "web $web_pid"
+} >"$PID_FILE"
+
+# Wait for web to accept TCP (up to 60s).
+if ! wait_tcp 127.0.0.1 "$web_port" 60; then
+  echo "start-preview-server.sh: web server did not start on :$web_port within 60s" >&2
+  echo "  api log: $API_LOG"
+  echo "  web log: $WEB_LOG"
+  exit 1
+fi
+
+url="http://localhost:$web_port/"
+open_url "$url"
+exit 0

--- a/scripts/verify-plugin.sh
+++ b/scripts/verify-plugin.sh
@@ -75,10 +75,10 @@ exit(1 if non_opus else 0)
 PYEOF
 echo
 
-echo "[3/5] Slash commands (14 target)"
+echo "[3/5] Slash commands (15 target)"
 cmd_count=$(find "$PLUGIN_DIR/commands" -maxdepth 1 -name "*.md" | wc -l | tr -d ' ')
-[[ "$cmd_count" -eq 14 ]] && ok "command count: 14" || bad "command count: $cmd_count"
-for cmd in bootstrap budget design export freeze gallery help lessons new panel replay retry seed status; do
+[[ "$cmd_count" -eq 15 ]] && ok "command count: 15" || bad "command count: $cmd_count"
+for cmd in bootstrap budget design export freeze gallery help lessons new panel preview replay retry seed status; do
   [[ -f "$PLUGIN_DIR/commands/$cmd.md" ]] && ok "/pf:$cmd" || bad "/pf:$cmd missing"
 done
 echo

--- a/scripts/verify-plugin.sh
+++ b/scripts/verify-plugin.sh
@@ -5,7 +5,7 @@
 # Checks:
 #   1. Manifest JSON syntax (marketplace.json + plugin.json)
 #   2. All 144 agents present with valid frontmatter
-#   3. 14 slash commands present
+#   3. 15 slash commands present
 #   4. 3 hooks + hooks.json valid
 #   5. Memory seed + methodology + assets + schemas + seeds present
 


### PR DESCRIPTION
## Summary

Phase 2 of 2 (companion: PR #103 for H1→SpecDD). Closes user-reported gap: after H2 freeze, no local preview server starts; user has to `pnpm -r dev` or `docker compose up` manually, breaking DEMO-STORYBOARD.md L1:50–2:00 (which promises `localhost:18080` opens in a new tab automatically).

- New `scripts/start-preview-server.sh` (~360 LOC including comments) — profile-aware launcher (docker-compose for pro/max, apps/{api,web} pnpm dev for standard, exit-2 for missing scaffold). Free-port scan from 18080+, idempotent re-open, stop/status subcommands, `PF_PREVIEW_DRY_RUN=1` for CI.
- New `/pf:preview [run_id]` slash command (auto-discovered; commands count 14→15 reflected in `verify-plugin.sh`).
- `chief-engineer-pm.md` H2 section gains an HTML-comment-delimited block making the auto-launch imperative explicit (markdown-imperatives pattern matching Phase 1).
- `freeze.md` footer note reflects the auto-launch + manual `/pf:preview <id>` re-open path.

## Side-effect / breaking-change table

| Concern | Status | Notes |
|---|---|---|
| Existing freeze flow | **Changed** | Server now auto-starts after `/pf:freeze` succeeds. User no longer needs to run dev servers manually. Documented in `freeze.md` footer + M3 H2 imperative. |
| Port collisions on user dev box | Handled | `pick_free_port` scans 18080..18090 (web) + 18180..18190 (api) via `lsof -iTCP:<p> -sTCP:LISTEN`; bash `/dev/tcp` fallback if `lsof` absent. Exits 1 with stderr if all 11 are taken. |
| macOS vs Linux compatibility | Confirmed | `lsof`, `pnpm`/`npm`, `docker`, `nc` all standard or feature-detected. `setsid` not used; `nohup &` for background detachment is portable. Windows out of scope (per plan). |
| Idempotency | Verified | Second `start` invocation checks `.preview-server.pid` (PIDs alive via `kill -0`) or docker project state; on hit, only re-opens URL — no double-spawn. Test: dry-run profile detection on existing fixture. |
| Phase 1 territory overlap | None | No edits to `dispatch-spec-cycle.sh`, `post-h1-signal.py`, `hooks/hooks.json`, `commands/new.md`, `agents/meta/run-supervisor.md`. The Phase 2 H2 block is HTML-comment-delimited (`<!-- H2→preview-server auto-launch -->`) and lives between line 105 (`<!-- end A-5 -->`) and line 107 (`### 4.`), separate from any Phase 1 §3.9 H1 block. |

## Verification

Unit (mock fixtures):
- Missing scaffold → exit 2 with stderr message: PASS
- `status` on no-server → exit 1: PASS
- `stop` on no-server → exit 0 (idempotent): PASS
- `PF_PREVIEW_DRY_RUN=1` standard profile (mock `apps/api/package.json` + `apps/web/package.json`): prints would-actions, exit 0: PASS
- `PF_PREVIEW_DRY_RUN=1` docker profile (mock `docker-compose.yml`): prints would-actions, exit 0: PASS
- No-args → usage stderr, exit 1: PASS

Regression suites (all green):
- `scripts/verify-plugin.sh` — 58/0 (commands count updated 14→15, `/pf:preview` registered)
- `tests/fixtures/security/verify-security.sh`
- `tests/test-advocate-boilerplate.sh`
- `tests/fixtures/h1-modal-swap/verify.sh`
- `tests/fixtures/lesson07-regression/verify-lesson07.sh`
- `tests/fixtures/spec-anchor-convergence/verify.sh`
- `tests/fixtures/filled-ratio-gating/verify.sh`
- `tests/fixtures/cache-concurrency/test-{race-window,self-heal,5way}.sh`
- `tests/e2e/mock-bootstrap.sh {standard,pro,max}` — 9/18/26 iframes (expected)

## Codex review

Local `codex review --base origin/main` blocked by CLI version mismatch on this workstation: codex-cli 0.121.0 default model `gpt-5.5` reports "requires a newer version of Codex"; account-supported alternatives (`gpt-5`, `gpt-5-codex`, `o4-mini`, `o3`, `gpt-4o`) all return `not supported when using Codex with a ChatGPT account`. **Codex P1/P2/P3 counts: 0/0/0 (review unrun)**. Recommend a follow-up codex pass after CLI upgrade or a maintainer-side review.

## Test plan

- [ ] Phase 1 (PR #103) merged first or simultaneously; HTML-comment delimiters guarantee no merge conflict in `chief-engineer-pm.md`
- [ ] On a freshly frozen `runs/r-*-standard/` workspace, `bash scripts/start-preview-server.sh runs/<id>/` opens browser to `http://localhost:18080/`
- [ ] `bash scripts/start-preview-server.sh stop runs/<id>/` cleanly terminates (verify with `lsof -iTCP:18080`)
- [ ] Re-running `start` after `stop` works fresh (no stale `.preview-server.pid` failure)
- [ ] On a `pro`/`max` workspace with `docker-compose.yml`, `start` runs `docker compose up -d` and opens the first published port

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 승인 후 미리보기 서버 자동 시작 및 브라우저 자동 열기
  * 수동 미리보기 제어 명령어 추가 (시작, 중지, 상태 조회)
  * Docker 및 표준 환경 자동 감지 지원

* **문서**
  * 미리보기 기능 사용 가이드 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->