### PR TITLE
docs(contributing): English-only language policy (#102)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,16 @@ Preview Forge introduces the **3-DD Methodology** (PreviewDD → SpecDD → Test
 Contributions that strengthen any one of the three cycles, or that close
 failure loops observed in real runs, are most welcome.
 
+## Language
+
+All issues, PRs, commits, code, and documentation in this repo are written in
+**English**. This keeps the artifact archive uniform and accessible to
+non-Korean reviewers, and matches the standard already followed by every
+shipped commit, PR body, CHANGELOG entry, and code comment. Korean prompts
+during a Claude Code session are not a switch signal — agents should reply
+in English by default. Make exceptions only for explicit, single-turn user
+directives.
+
 ## Commit message convention
 
 This repo uses **release-please** with [Conventional Commits](https://www.conventionalcommits.org/).


### PR DESCRIPTION
## Summary

Adds a "Language" section to `CONTRIBUTING.md` so the English-only standard is repo-discoverable rather than living only in agent memory.

Repo language has been inconsistent: shipped artifacts (README, code, commits, CHANGELOG, PR bodies) are English, but 23 issues from an auditor agent (#58–#80) shipped in Korean — see #102 for the root cause analysis.

## Test plan

- [x] Verified `head -10 CONTRIBUTING.md` shows the new section
- [x] No regression to existing CONTRIBUTING content (commit message convention, PR checklist, agent count etc. all preserved)

## Codex review

Skipped this pass — single-paragraph documentation addition, zero code surface, no behavior change.

Refs #102 (does not close — body-level translation of #58–#80 is the remaining acceptance-criteria item)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서

* **Documentation**
  * 기여 가이드에 언어 정책 섹션을 추가하여 이슈, PR, 커밋, 코드 및 문서의 기본 언어를 명시
  * AI 도구와의 상호작용에 대한 명확한 지침 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->