### PR TITLE
feat(methodology): Rule 10 — Output language English (Layer-0)

### DIFF
--- a/plugins/preview-forge/methodology/global.md
+++ b/plugins/preview-forge/methodology/global.md
@@ -6,7 +6,7 @@
 
 ---
 
-## 7개 비협상 규칙 (Non-negotiable Rules)
+## Layer-0 비협상 규칙 (Non-negotiable Rules)
 
 ### Rule 1 — Gate 없이 진행 금지
 - PreviewDD → SpecDD 전환은 Gate H1 (인간 디자인 승인) 없이 불가
@@ -99,6 +99,43 @@ export PF_DRIFT_BYPASS=1 PF_DRIFT_REASON="SpecDD explicitly expanding to include
 - Gate H1 완료 전 (chosen_preview.json 없음) → no-op
 - 120자 미만 write → no-op (오타 수정 false positive 방지)
 
+### Rule 10 — Output language: English (v1.13+)
+
+All user-facing output produced by any of the 144 agents in this plugin
+**MUST be in English**, regardless of the language the user prompts in.
+This includes (non-exhaustive):
+
+- `AskUserQuestion` modal `question`, `header`, option `label` and
+  `description` fields
+- Console / chat prose responses to the user
+- Status messages, progress updates, standup summaries
+- Modal labels at Gate H1 and Gate H2
+- Error messages surfaced to the user
+- Generated artifacts that the user reads directly:
+  `mockups/gallery-text.md`, `score/report.json` summaries,
+  `runs/<id>/trace.log` user-facing lines
+
+**Why**: this plugin's archive (commits, PR bodies, root CHANGELOG, code,
+schemas) is English-only — see `CONTRIBUTING.md` "Language" section.
+A bilingual user surface defeats searchability for non-Korean reviewers
+and contradicts the documented policy. Korean prompts from the user are
+**not** a switch signal — agents reply in English by default.
+
+**Single-turn override**: only when the user issues an explicit per-turn
+directive such as *"reply in Korean for this answer"*. Once the turn
+ends, the next response returns to English.
+
+**Markdown of the agent files themselves**: the prose **inside**
+`agents/**/*.md` and `commands/*.md` may stay in Korean for maintenance
+(many existing agent prompts are in Korean). What's enforced is the
+*output the agent emits to the user*, not the language of the prompt
+the agent was authored in.
+
+**Enforcement**: this rule is Layer-0; `factory-policy.py` does not
+parse natural-language output, so enforcement is by agent compliance.
+A future hook may scan `AskUserQuestion` modal payloads for Hangul code
+points and warn — tracked separately.
+
 ---
 
 ## 모델 · effort 강제 정책
@@ -153,4 +190,4 @@ Per-call payload cap: 1-4 questions per AskUserQuestion call (Claude Code tool s
 
 ## 불변 원칙
 
-이 문서는 plugin v1.0.0 기준 7 rules를 정의합니다. v2.0.0 이전까지 **추가만 가능, 수정·삭제 불가**. v2.0.0에서 breaking change가 있을 경우에도 각 규칙의 의도는 유지되어야 합니다.
+이 문서는 plugin v1.0.0 기준 7 rules로 출발하여 점진적으로 확장되었습니다 (현재 Rule 10까지). v2.0.0 이전까지 **추가만 가능, 수정·삭제 불가**. v2.0.0에서 breaking change가 있을 경우에도 각 규칙의 의도는 유지되어야 합니다.


### PR DESCRIPTION
## Summary

Adds Rule 10 to `plugins/preview-forge/methodology/global.md` enforcing **English-only user-facing output** from all 144 plugin agents. Closes the gap that #102 didn't cover — #102 was archive cleanup (CONTRIBUTING + 23 issue translations), but did not constrain what users actually see when they invoke the plugin.

## What changed

- New **Rule 10** added after Rule 9 in `methodology/global.md`. Covers AskUserQuestion modals, console prose, status messages, Gate H1/H2 labels, user-readable generated artifacts.
- Rationale, single-turn override exception, and scope clarification (rule constrains *output*, not the language of the agent's own markdown prompt).
- Section title updated `7개 비협상 규칙` → `Layer-0 비협상 규칙` (count was already stale because Rules 8/9 were added in v1.2/v1.3).
- 불변 원칙 footer acknowledges Rules 1-10.

## Why this is enough (no per-agent edit needed)

All 144 agents already include `@methodology/global.md` in their Layer-0 directive at the top of their frontmatter. Adding a rule to that single file propagates the constraint to every agent automatically. No need to touch each agent file individually.

## Side effects

- **No code change** in any script, hook, or agent prompt
- **No advocate boilerplate change** — `tests/test-advocate-boilerplate.sh` still passes (lint scope is `agents/ideation/advocates/P*.md`, not `methodology/`)
- **`bash scripts/verify-plugin.sh` → 58 Pass / 0 Fail**
- **No new fixture** — natural-language output enforcement is hard to lint deterministically; PR body notes that a future Hangul-codepoint scanner hook is tracked separately

## Test plan

- [x] `bash scripts/verify-plugin.sh` → Pass 58/0
- [x] grep verification: rule landed at the right anchor in global.md
- Manual e2e (recommended after merge + plugin update): run `/pf:new "..."` in Korean and verify the AskUserQuestion modals appear in English

## Codex review

Skipped — single-file documentation rule addition, zero code surface, no behavior change.

Refs #102